### PR TITLE
added simple TagEntry

### DIFF
--- a/entry_tag.go
+++ b/entry_tag.go
@@ -1,0 +1,6 @@
+package qdb
+
+// TagEntry : tag data type
+type TagEntry struct {
+	Entry
+}

--- a/handle.go
+++ b/handle.go
@@ -270,6 +270,11 @@ func (h HandleType) Timeseries(alias string) TimeseriesEntry {
 	return TimeseriesEntry{Entry{h, alias}}
 }
 
+// Tag : Create a tag entry object
+func (h HandleType) Tag(alias string) TagEntry {
+	return TagEntry{Entry{h, alias}}
+}
+
 // Node : Create a node object
 func (h HandleType) Node(uri string) *Node {
 	return &Node{h, uri}


### PR DESCRIPTION
Simple "TagEntry" was added. In this case it's possible to:

Get tags of a tag:
`tags, err := handle.Tag("EVA-00").GetTags()`

Get object names which are tagged by:
`items, err := handle.Tag("").GetTagged("#device")`
