### PR TITLE
Improve codex setup script

### DIFF
--- a/scripts/codex/setup.sh
+++ b/scripts/codex/setup.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# Exit immediately if a command exits with a non-zero status,
+# if an undefined variable is used, or if any command in a pipeline fails.
+set -euo pipefail
+
 ##
 # Download dependencies for codex in the correct directory. Assumes to be invoked from the project root,
 # assumes the latest nightly quasardb build.
@@ -11,15 +15,15 @@ QDB_PATH="$(pwd)/qdb/"
 # Utility functions
 
 function die {
-    echo $1
-    exit -1
+    echo "$1"
+    exit 1
 }
 
 
 ##
 # Download nightly quasardb artifacts and extract in qdb/ subdirectory.
 
-if [ ! -d ${QDB_PATH} ]
+if [ ! -d "${QDB_PATH}" ]
 then
     echo "${QDB_PATH} does not yet exist, downloading and extracting tarballs into there."
 
@@ -37,20 +41,20 @@ then
     for URL in "${URLS[@]}"
     do
         echo "Checking: ${URL}..."
-        curl -s --head --fail ${URL} > /dev/null || die "Url not found: ${URL}"
+        curl -s --head --fail "${URL}" > /dev/null || die "Url not found: ${URL}"
     done
 
     echo "Extracting each tarball into qdb/ subdirectory"
-    mkdir ${QDB_PATH}
-    pushd ${QDB_PATH}
+    mkdir "${QDB_PATH}"
+    pushd "${QDB_PATH}" > /dev/null
 
     for URL in "${URLS[@]}"
     do
         echo "Downloading and extracting: ${URL}..."
-        curl -s -L ${URL} | tar -xzf -
+        curl -s -L "${URL}" | tar -xzf -
     done
 
-    popd
+    popd > /dev/null
 
     echo "Done downloading files quasardb dependencies: "
     find qdb/


### PR DESCRIPTION
## Summary
- add strict error handling to the codex setup helper
- quote variables and silence pushd/popd
- remove unnecessary -p from mkdir

## Testing
- `go test ./...` *(fails: no network access to fetch dependencies)*