### PR TITLE
Improve Codex setup and instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,13 @@ This Agents.md file provides comprehensive guidance for OpenAI Codex and other A
 
 ### Test setup
 
-From the project root execute:
+Ensure all dependencies are available before starting any services:
+
+```bash
+bash scripts/codex/setup.sh
+```
+
+From the project root execute the startup script to launch the test clusters:
 
 ```bash
 bash scripts/tests/setup/start-services.sh
@@ -31,7 +37,7 @@ bash scripts/teamcity/20.test.sh
 ```
 
 ### Tests teardown
-From the project root execute:
+From the project root execute the shutdown script:
 
 ```bash
 bash scripts/tests/setup/stop-services.sh

--- a/scripts/codex/setup.sh
+++ b/scripts/codex/setup.sh
@@ -19,6 +19,14 @@ function die {
     exit 1
 }
 
+# Ensure git submodules are available before performing any build steps.
+echo "Checking out git submodules"
+git submodule update --init --recursive
+
+# Install runtime utilities needed by the test scripts.
+echo "Installing test dependencies"
+apt-get update -y && apt-get install -y lsof >/dev/null
+
 
 ##
 # Download nightly quasardb artifacts and extract in qdb/ subdirectory.
@@ -76,10 +84,3 @@ bash scripts/teamcity/10.build.sh
 # case by executing `go mod download`.
 go mod download
 
-##
-# Codex *may* also not check out submodules. To make sure these are checked out, and since
-# this is the last time we're able to use the internet, let's make sure they are checked
-# out.
-echo "Checking out git submodules"
-
-git submodule update --init --recursive


### PR DESCRIPTION
## Summary
- clarify setup and test sequence for Codex in `AGENTS.md`
- ensure git submodules are fetched and runtime deps installed in `scripts/codex/setup.sh`

## Testing
- `bash scripts/codex/setup.sh`
- `bash scripts/tests/setup/start-services.sh` *(fails: `lsof` missing)*
- `bash scripts/tests/setup/stop-services.sh`