### PR TITLE
Implement newReaderDataInt64

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -7,7 +7,10 @@ package qdb
 	#include <qdb/ts.h>
 */
 import "C"
-import "fmt"
+import (
+	"fmt"
+	"unsafe"
+)
 
 type ReaderData interface {
 	// Returns the column name
@@ -35,19 +38,32 @@ type ReaderDataInt64 struct {
 // xs:   C array of reader column data
 // n:    length of `data` inside array
 func newReaderDataInt64(name string, xs C.qdb_exp_batch_push_column_t, n int) (ReaderDataInt64, error) {
-	// Step 1: validate xs is of type qdb_ts_column_int64, yield error otherwise
+	// Step 1: validation of input parameters
 	if xs.data_type != C.qdb_ts_column_int64 {
 		return ReaderDataInt64{}, fmt.Errorf("Internal error, expected data type to be int64, got: %v", xs.data_type)
+	}
+	if n <= 0 {
+		return ReaderDataInt64{}, fmt.Errorf("Internal error: invalid column length %d", n)
 	}
 
 	// Step 2: do a cast of xs.data[0] to *C.qdb_int_t. As pointer sizes on different architectures
 	//         may differ, *cannot* assume it's 8 bytes, and instead use `unsafe.Pointer` as the
 	//         architecture-safe representation for the size.
+	rawPtr := *(*unsafe.Pointer)(unsafe.Pointer(&xs.data[0]))
+	cPtr := (*C.qdb_int_t)(rawPtr)
+	if cPtr == nil {
+		return ReaderDataInt64{}, fmt.Errorf("Internal error: nil data pointer for column %s", name)
+	}
 
 	// Step 3: copy data by first interpreting it as a temporary memory unsafe-slice, then copying
 	//         it into a new, entirely Go-managed slice. This ensures the data can live on even when
 	//         we move to a new "batch" of reader data.
+	out := ReaderDataInt64{name: name, xs: make([]int64, n)}
+	tmp := unsafe.Slice(cPtr, n)
+	for i, v := range tmp {
+		out.xs[i] = int64(v)
+	}
 
 	// Return result
-	return ReaderDataInt64{}, nil
+	return out, nil
 }


### PR DESCRIPTION
## Summary
- implement `newReaderDataInt64` for converting bulk reader column data
- add `unsafe` import for pointer handling
- validate inputs and remove redundant checks

## Testing
- `bash scripts/tests/setup/start-services.sh`
- `bash scripts/teamcity/20.test.sh`
- `bash scripts/tests/setup/stop-services.sh`
