### PR TITLE
Fix reader range validation

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -52,8 +52,15 @@ func TestReaderReturnsErrorOnInvalidRange(t *testing.T) {
 	_, err = NewReader(handle, opts)
 	assert.Error(err)
 
-	// TODO: implement test case that tests setting an IsZero() time for the start,
-	//       but a non-IsZero for the end, and vice versa.
+	// Error when start is zero but end is non-zero
+	opts = opts.WithTimeRange(time.Time{}, time.Unix(5, 0))
+	_, err = NewReader(handle, opts)
+	assert.Error(err)
+
+	// Error when start is non-zero but end is zero
+	opts = opts.WithTimeRange(time.Unix(5, 0), time.Time{})
+	_, err = NewReader(handle, opts)
+	assert.Error(err)
 }
 
 func TestReaderCanOpenWithValidOptions(t *testing.T) {


### PR DESCRIPTION
## Summary
- validate reader range start/end pair
- allocate native range buffer
- test invalid time range combinations

## Testing
- `bash scripts/teamcity/20.test.sh`

------
https://chatgpt.com/codex/tasks/task_b_683d206ced208327b0dabe34b084d44b