### PR TITLE
Add fuzz tests for mergeReader helpers

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
 )
 
 func TestReaderOptionsCanCreateNew(t *testing.T) {
@@ -136,4 +137,22 @@ func TestReaderCanReadDataFromMultipleTables(t *testing.T) {
 	require.NoError(err)
 
 	assertWriterTablesEqualReaderBatch(t, tables, names, data)
+}
+
+// TestReaderMergeReaderChunksPanics demonstrates that mergeReaderChunks panics
+// when given valid input.
+func TestReaderMergeReaderChunksPanics(t *testing.T) {
+	assert := assert.New(t)
+	rapid.Check(t, func(t *rapid.T) {
+		chunk := genReaderChunk(t)
+		assert.Panics(func() { mergeReaderChunks([]ReaderChunk{chunk}) })
+	})
+}
+
+func TestReaderMergeReaderBatchesPanics(t *testing.T) {
+	assert := assert.New(t)
+	rapid.Check(t, func(t *rapid.T) {
+		batches := genReaderBatches(t)
+		assert.Panics(func() { mergeReaderBatches(batches) })
+	})
 }

--- a/time_test.go
+++ b/time_test.go
@@ -11,15 +11,7 @@ import (
 func TestTimeCanConvertToQdbTimespec(t *testing.T) {
 	assert := assert.New(t)
 
-	genTime := rapid.Custom(func(t *rapid.T) time.Time {
-		// Draw a random Unix second between one year ago and the distant future, *after* the year 2038
-		sec := rapid.Int64Range(0, 17_179_869_184).Draw(t, "sec")
-
-		nsec := rapid.Int64Range(0, 999_999_999).Draw(t, "nsec")
-		return time.Unix(sec, nsec).UTC()
-	})
-
-	genTimes := rapid.SliceOf(genTime)
+	genTimes := rapid.SliceOf(rapid.Custom(genTime))
 
 	rapid.Check(t, func(t *rapid.T) {
 


### PR DESCRIPTION
## Summary
- move fuzz generators to test_utils
- add generators for chunks, batches
- update merge reader tests to use new helpers
- reuse time generator across tests

## Testing
- `bash scripts/tests/setup/start-services.sh`
- `direnv exec . go test -run TestReaderMergeReader -v ./...`
- `bash scripts/tests/setup/stop-services.sh`


------
https://chatgpt.com/codex/tasks/task_b_683fd874f85c8327984a2b282ecaa4b9