### PR TITLE
Implement assertReaderChunksEqualChunk

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -142,12 +142,12 @@ func TestReaderCanReadDataFromMultipleTables(t *testing.T) {
 // TestReaderMergeReaderChunksPanics demonstrates that mergeReaderChunks panics
 // when given valid input.
 func TestReaderMergeReaderChunks(t *testing.T) {
-	rapid.Check(t, func(t *rapid.T) {
-		xs := genReaderChunks(t)
+	rapid.Check(t, func(rt *rapid.T) {
+		xs := genReaderChunks(rt)
 		ret, err := mergeReaderChunks(xs)
 
-		assert.NoError(t, err)
+		assert.NoError(rt, err)
 
-		assertReaderChunksEqualChunk(xs, ret)
+		assertReaderChunksEqualChunk(t, xs, ret)
 	})
 }


### PR DESCRIPTION
## Summary
- implement helper to verify merged ReaderChunk
- refactor function to take *testing.T and use testify for validation

## Testing
- `bash scripts/tests/setup/start-services.sh`
- `direnv exec . go test -v ./... -run 'TestReaderMergeReaderChunks'`
- `bash scripts/tests/setup/stop-services.sh`


------
https://chatgpt.com/codex/tasks/task_b_68402c21cc148327ae6a90a4132cfef3