### PR TITLE
Add push flag utilities and tests

### DIFF
--- a/writer_test.go
+++ b/writer_test.go
@@ -112,6 +112,28 @@ func TestWriterOptionsCanSetProperties(t *testing.T) {
 	// Setting deduplication mode explicitly to upsert
 	options = options.WithDeduplicationMode(WriterDeduplicationModeUpsert)
 	assert.Equal(WriterDeduplicationModeUpsert, options.GetDeduplicationMode())
+
+	// Verify write-through flag manipulation
+	options = NewWriterOptions()
+	assert.True(options.IsWriteThroughEnabled())
+
+	options = options.DisableWriteThrough()
+	assert.False(options.IsWriteThroughEnabled())
+	assert.False(options.IsAsyncClientPushEnabled())
+
+	// enable async first then re-enable write through
+	options = options.EnableAsyncClientPush().EnableWriteThrough()
+	assert.True(options.IsAsyncClientPushEnabled())
+	assert.True(options.IsWriteThroughEnabled())
+
+	// disable only write through; async should remain
+	options = options.DisableWriteThrough()
+	assert.False(options.IsWriteThroughEnabled())
+	assert.True(options.IsAsyncClientPushEnabled())
+
+	// disable async; write-through untouched
+	options = options.DisableAsyncClientPush()
+	assert.False(options.IsAsyncClientPushEnabled())
 }
 
 func TestWriterCanCreateNew(t *testing.T) {


### PR DESCRIPTION
## Summary
- implement WriterOptions helpers for manipulating push flags
- document the new methods using bullet-style comments
- extend TestWriterOptionsCanSetProperties to test async and write-through flag combinations

## Testing
- `bash scripts/tests/setup/start-services.sh`
- `direnv exec . go test -v ./...`
- `bash scripts/tests/setup/stop-services.sh`


------
https://chatgpt.com/codex/tasks/task_b_684151facda483278e973438b5b81ab0