### PR TITLE
Add writer option validation and rapid-based writer tests

### DIFF
--- a/test_utils.go
+++ b/test_utils.go
@@ -706,3 +706,49 @@ func assertReaderChunksEqualChunk(t *testing.T, lhs []ReaderChunk, rhs ReaderChu
 
 	assert.Equal(t, lhsIdx, rhsIdx, "index mismatch")
 }
+
+// -- WriterOptions generators -------------------------------------------------
+
+var writerPushModes = []WriterPushMode{
+	WriterPushModeTransactional,
+	WriterPushModeFast,
+	WriterPushModeAsync,
+}
+
+func genWriterPushMode(t *rapid.T) WriterPushMode {
+	return rapid.SampledFrom(writerPushModes[:]).Draw(t, "writerPushMode")
+}
+
+var writerPushFlags = []WriterPushFlag{
+	WriterPushFlagNone,
+	WriterPushFlagWriteThrough,
+	WriterPushFlagAsyncClientPush,
+	WriterPushFlagWriteThrough | WriterPushFlagAsyncClientPush,
+}
+
+func genWriterPushFlag(t *rapid.T) WriterPushFlag {
+	return rapid.SampledFrom(writerPushFlags[:]).Draw(t, "writerPushFlag")
+}
+
+var writerDedupModes = []WriterDeduplicationMode{
+	WriterDeduplicationModeDisabled,
+	WriterDeduplicationModeDrop,
+}
+
+func genWriterDedupMode(t *rapid.T) WriterDeduplicationMode {
+	return rapid.SampledFrom(writerDedupModes[:]).Draw(t, "writerDedupMode")
+}
+
+func genWriterOptions(t *rapid.T) WriterOptions {
+	opts := NewWriterOptions()
+	opts.pushMode = genWriterPushMode(t)
+	opts.pushFlags = genWriterPushFlag(t)
+	opts = opts.WithDeduplicationMode(genWriterDedupMode(t))
+	opts.dropDuplicateColumns = nil
+
+	if !opts.IsValid() {
+		panic("genWriterOptions produced invalid options")
+	}
+
+	return opts
+}


### PR DESCRIPTION
## Summary
- add `WriterOptions.IsValid` to centralize sanity checks
- generate random `WriterOptions` for testing
- add property-based tests for writer push logic using rapid

## Testing
- `bash scripts/tests/setup/start-services.sh`
- `direnv exec . go test -v ./... -run 'TestWriterOptionsGenerator|TestWriterCanPushTables'`
- `bash scripts/tests/setup/stop-services.sh`


------
https://chatgpt.com/codex/tasks/task_b_68416d1395e48327a2650cd229c5cf1d