### PR TITLE
Add deduplication test

### DIFF
--- a/writer_test.go
+++ b/writer_test.go
@@ -324,3 +324,66 @@ func TestWriterCanPushTables(t *testing.T) {
 		require.NoError(rt, writer.Push(handle))
 	})
 }
+func TestWriteCanDeduplicate(t *testing.T) {
+	assert := assert.New(t)
+
+	rapid.Check(t, func(rt *rapid.T) {
+		handle := newTestHandle(t)
+		defer handle.Close()
+
+		tableCount := rapid.IntRange(1, 4).Draw(rt, "tableCount")
+		tables := genPopulatedTables(rt, handle, tableCount)
+
+		names := writerTableNames(tables)
+		columns := writerTablesColumns(tables)
+		columnNames := columnNamesFromWriterColumns(columns)
+
+		// Initial push without deduplication.
+		writer := NewWriterWithDefaultOptions()
+		for _, wt := range tables {
+			require.NoError(rt, writer.SetTable(wt))
+		}
+		require.NoError(rt, writer.Push(handle))
+
+		opts := NewReaderOptions().WithTables(names).WithColumns(columnNames)
+		reader, err := NewReader(handle, opts)
+		require.NoError(rt, err)
+		defer reader.Close()
+
+		baseData, err := reader.FetchAll()
+		require.NoError(rt, err)
+		assertWriterTablesEqualReaderChunks(t, tables, names, baseData)
+
+		// Push again with deduplication enabled.
+		writer = NewWriter(NewWriterOptions().EnableDropDuplicates())
+		for _, wt := range tables {
+			require.NoError(rt, writer.SetTable(wt))
+		}
+		require.NoError(rt, writer.Push(handle))
+
+		reader2, err := NewReader(handle, opts)
+		require.NoError(rt, err)
+		defer reader2.Close()
+		dedupData, err := reader2.FetchAll()
+		require.NoError(rt, err)
+		assertWriterTablesEqualReaderChunks(t, tables, names, dedupData)
+
+		// Push once more without deduplication.
+		writer = NewWriterWithDefaultOptions()
+		for _, wt := range tables {
+			require.NoError(rt, writer.SetTable(wt))
+		}
+		require.NoError(rt, writer.Push(handle))
+
+		// Verify each table now contains twice the original rows.
+		for _, wt := range tables {
+			rcOpts := NewReaderOptions().WithTables([]string{wt.GetName()}).WithColumns(columnNames)
+			r, err := NewReader(handle, rcOpts)
+			require.NoError(rt, err)
+			data, err := r.FetchAll()
+			r.Close()
+			require.NoError(rt, err)
+			assert.Equal(len(wt.GetIndex())*2, data.RowCount())
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- ensure Writer handles deduplication correctly

## Testing
- `direnv exec . go test -v ./... -run 'TestWriteCanDeduplicate'` *(fails: exit status 1)*

------
https://chatgpt.com/codex/tasks/task_b_68417d53dee88327bc9c02b62e0fb01d