### PR TITLE
Enable assert helpers for rapid

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -112,7 +112,7 @@ func TestReaderCanReadDataFromSingleTable(t *testing.T) {
 		data, err := reader.FetchAll()
 		require.NoError(rt, err)
 
-		assertWriterTablesEqualReaderChunks(t, tables, names, data)
+		assertWriterTablesEqualReaderChunks(rt, tables, names, data)
 	})
 }
 
@@ -137,7 +137,7 @@ func TestReaderCanReadDataFromMultipleTables(t *testing.T) {
 		data, err := reader.FetchAll()
 		require.NoError(rt, err)
 
-		assertWriterTablesEqualReaderChunks(t, tables, names, data)
+		assertWriterTablesEqualReaderChunks(rt, tables, names, data)
 	})
 }
 
@@ -150,6 +150,6 @@ func TestReaderMergeReaderChunks(t *testing.T) {
 
 		assert.NoError(rt, err)
 
-		assertReaderChunksEqualChunk(t, xs, ret)
+		assertReaderChunksEqualChunk(rt, xs, ret)
 	})
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -352,7 +352,7 @@ func TestWriteCanDeduplicate(t *testing.T) {
 
 		baseData, err := reader.FetchAll()
 		require.NoError(rt, err)
-		assertWriterTablesEqualReaderChunks(t, tables, names, baseData)
+		assertWriterTablesEqualReaderChunks(rt, tables, names, baseData)
 
 		// Push again with deduplication enabled.
 		writer = NewWriter(NewWriterOptions().EnableDropDuplicates())
@@ -366,7 +366,7 @@ func TestWriteCanDeduplicate(t *testing.T) {
 		defer reader2.Close()
 		dedupData, err := reader2.FetchAll()
 		require.NoError(rt, err)
-		assertWriterTablesEqualReaderChunks(t, tables, names, dedupData)
+		assertWriterTablesEqualReaderChunks(rt, tables, names, dedupData)
 
 		// Push once more without deduplication.
 		writer = NewWriterWithDefaultOptions()


### PR DESCRIPTION
## Summary
- add `testHelper` interface for `require` compatibility
- refactor assert helper funcs to accept any test framework
- update reader and writer tests to use `rapid.T`

## Testing
- `bash scripts/tests/setup/start-services.sh`
- `direnv exec . go test ./... -run TestReaderMergeReaderChunks -count=1 -v`
- `bash scripts/tests/setup/stop-services.sh`


------
https://chatgpt.com/codex/tasks/task_b_68418522418083278f5d633800987b28