### PR TITLE
Improve comments for writer and reader utilities

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -883,21 +883,27 @@ func NewReaderDefaultOptions(tables []string) ReaderOptions {
 	return NewReaderOptions().WithTables(tables)
 }
 
+// WithBatchSize specifies the maximum rows returned per fetch.
+// Use smaller sizes to limit memory usage at the cost of more network calls.
 func (ro ReaderOptions) WithBatchSize(batchSize int) ReaderOptions {
 	ro.batchSize = batchSize
 	return ro
 }
 
+// WithTables restricts the reader to the provided table names.
 func (ro ReaderOptions) WithTables(tables []string) ReaderOptions {
 	ro.tables = tables
 	return ro
 }
 
+// WithColumns limits which columns are read from each table.
+// An empty slice implies all columns.
 func (ro ReaderOptions) WithColumns(columns []string) ReaderOptions {
 	ro.columns = columns
 	return ro
 }
 
+// WithTimeRange restricts reads to the given half-open interval [start, end).
 func (ro ReaderOptions) WithTimeRange(start time.Time, end time.Time) ReaderOptions {
 	ro.rangeStart = start
 	ro.rangeEnd = end

--- a/time.go
+++ b/time.go
@@ -15,10 +15,12 @@ type Timespec C.qdb_timespec_t
 // Alias for `C.qdb_time_t` so it can be used as `qdb.Time` by API users
 type Time C.qdb_time_t
 
+// toQdbTimespec converts a Go time.Time to the C qdb_timespec_t representation.
 func toQdbTimespec(tp time.Time) C.qdb_timespec_t {
 	return C.qdb_timespec_t{C.qdb_time_t(tp.Unix()), C.qdb_time_t(tp.Nanosecond())}
 }
 
+// toQdbTime converts a time.Time to the qdb_time_t millisecond format used by the C API.
 func toQdbTime(tp time.Time) C.qdb_time_t {
 	if tp.Equal(PreserveExpiration()) {
 		return C.qdb_preserve_expiration
@@ -26,6 +28,7 @@ func toQdbTime(tp time.Time) C.qdb_time_t {
 	return C.qdb_time_t(tp.UnixNano() / int64(time.Millisecond))
 }
 
+// toQdbRange builds a qdb_ts_range_t from begin and end times.
 func toQdbRange(begin time.Time, end time.Time) C.qdb_ts_range_t {
 	var ret C.qdb_ts_range_t
 	ret.begin = toQdbTimespec(begin)
@@ -33,22 +36,23 @@ func toQdbRange(begin time.Time, end time.Time) C.qdb_ts_range_t {
 	return ret
 }
 
+// TimespecToStructG converts qdb_timespec_t to time.Time in local timezone.
 func TimespecToStructG(tp C.qdb_timespec_t) time.Time {
 	return time.Unix(int64(tp.tv_sec), int64(tp.tv_nsec))
 }
 
-// Converts a single time.Time value to a native C qdb_timespec_t value
+// TimeToQdbTimespec writes t into out using the qdb_timespec_t format.
 func TimeToQdbTimespec(t time.Time, out *C.qdb_timespec_t) {
 	out.tv_nsec = C.qdb_time_t(t.Nanosecond())
 	out.tv_sec = C.qdb_time_t(t.Unix())
 }
 
-// Converts a single native C qdb_timespec_t to a time.Time
+// QdbTimespecToTime converts qdb_timespec_t to a UTC time.Time.
 func QdbTimespecToTime(t C.qdb_timespec_t) time.Time {
 	return time.Unix(int64(t.tv_sec), int64(t.tv_nsec)).UTC()
 }
 
-// Converts a slice of `time.Time` values to a slice of native C qdb_timespec_t values
+// TimeSliceToQdbTimespec converts a slice of time.Time values to qdb_timespec_t slice.
 func TimeSliceToQdbTimespec(xs []time.Time) []C.qdb_timespec_t {
 	ret := make([]C.qdb_timespec_t, len(xs))
 
@@ -59,7 +63,7 @@ func TimeSliceToQdbTimespec(xs []time.Time) []C.qdb_timespec_t {
 	return ret
 }
 
-// Converts a slice of `time.Time` values to a slice of native C qdb_timespec_t values
+// QdbTimespecSliceToTime converts a slice of qdb_timespec_t to time.Time values.
 func QdbTimespecSliceToTime(xs []C.qdb_timespec_t) []time.Time {
 	ret := make([]time.Time, len(xs))
 


### PR DESCRIPTION
## Summary
- document WriterTable getters and index helpers
- add cleanup helper comments for batch push columns
- clarify ReaderOptions configuration helpers
- add internal documentation for time conversion helpers

## Testing
- `bash scripts/tests/setup/start-services.sh`
- `direnv exec . go test -v ./...`
- `bash scripts/tests/setup/stop-services.sh`


------
https://chatgpt.com/codex/tasks/task_b_6842d02baf448327ab59b3e64b646f32