### PR TITLE
Improve error management

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -5,6 +5,7 @@ package qdb
 	#include <stdlib.h>
 */
 import "C"
+
 import (
 	"fmt"
 	"math"

--- a/cluster.go
+++ b/cluster.go
@@ -25,7 +25,7 @@ type Cluster struct {
 //	By default cluster does not allow this operation and the function returns a qdb_e_operation_disabled error.
 func (c Cluster) PurgeAll() error {
 	err := C.qdb_purge_all(c.handle, 60*1000)
-	return makeErrorOrNil(err)
+	return wrapError(err, "cluster_purge_all")
 }
 
 // PurgeCache : Removes all cached data from all the nodes of the cluster.
@@ -36,7 +36,7 @@ func (c Cluster) PurgeAll() error {
 //	This call is not atomic: if the command cannot be dispatched on the whole cluster, it will be dispatched on as many nodes as possible and the function will return with a qdb_e_ok code.
 func (c Cluster) PurgeCache() error {
 	err := C.qdb_purge_cache(c.handle, 60*1000)
-	return makeErrorOrNil(err)
+	return wrapError(err, "cluster_purge_cache", "timeout_ms", 60*1000)
 }
 
 // TrimAll : Trims all data on all the nodes of the cluster.
@@ -49,7 +49,7 @@ func (c Cluster) PurgeCache() error {
 //	Because this operation is I/O and CPU intensive it is not recommended to run it when the cluster is heavily used.
 func (c Cluster) TrimAll() error {
 	err := C.qdb_trim_all(c.handle, 0, 60*60*1000)
-	return makeErrorOrNil(err)
+	return wrapError(err, "cluster_trim_all")
 }
 
 // WaitForStabilization : Wait for all nodes of the cluster to be stabilized.
@@ -57,7 +57,7 @@ func (c Cluster) TrimAll() error {
 //	Takes a timeout value, in milliseconds.
 func (c Cluster) WaitForStabilization(timeout time.Duration) error {
 	err := C.qdb_wait_for_stabilization(c.handle, C.int(timeout/time.Millisecond))
-	return makeErrorOrNil(err)
+	return wrapError(err, "cluster_wait_for_stabilization", "timeout", timeout)
 }
 
 // Endpoint : A structure representing a qdb url endpoint
@@ -101,5 +101,5 @@ func (c Cluster) Endpoints() ([]Endpoint, error) {
 		defer c.Release(unsafe.Pointer(endpoints))
 		return endpointArrayToGo(endpoints, endpointsCount), nil
 	}
-	return nil, makeErrorOrNil(err)
+	return nil, wrapError(err, "cluster_trim_all")
 }

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -78,7 +78,7 @@ func TestClusterTrimAllWithExistingData(t *testing.T) {
 	cluster := handle.Cluster()
 	err = cluster.TrimAll()
 	assert.NoError(t, err)
-	
+
 	// Verify blob still exists after trim
 	contentObtained, err := blob.Get()
 	assert.NoError(t, err)

--- a/column_data.go
+++ b/column_data.go
@@ -5,11 +5,12 @@ package qdb
 	#include <qdb/ts.h>
 */
 import "C"
+
 import (
 	"fmt"
+	"runtime"
 	"time"
 	"unsafe"
-	"runtime"
 )
 
 // ColumnData unifies both Reader and Writer data interfaces.
@@ -75,7 +76,6 @@ type ColumnDataInt64 struct {
 	xs []int64
 }
 
-
 // Length reports the number of int64 values held in the column.
 func (cd *ColumnDataInt64) Length() int {
 	return len(cd.xs)
@@ -97,8 +97,9 @@ func (cd *ColumnDataInt64) Clear() {
 }
 
 // PinToC exposes the Go slice to C without copying:
-//   – pins the slice base so it stays immovable
-//   – returns a no-op release closure
+//
+//	– pins the slice base so it stays immovable
+//	– returns a no-op release closure
 func (cd *ColumnDataInt64) PinToC(p *runtime.Pinner, h HandleType) (unsafe.Pointer, func()) {
 	if len(cd.xs) == 0 {
 		return nil, func() {}
@@ -155,7 +156,6 @@ Usage example:
 	data := cd.Data()
 */
 func newColumnDataInt64FromNative(name string, xs C.qdb_exp_batch_push_column_t, n int) (ColumnDataInt64, error) {
-
 	// Ensure the column type matches int64; mismatches lead to invalid reads.
 	if xs.data_type != C.qdb_ts_column_int64 {
 		return ColumnDataInt64{},
@@ -274,8 +274,9 @@ func (cd *ColumnDataDouble) appendDataUnsafe(d ColumnData) {
 }
 
 // PinToC exposes the Go slice to C without copying:
-//   – pins the slice base so it stays immovable
-//   – returns a no-op release closure
+//
+//	– pins the slice base so it stays immovable
+//	– returns a no-op release closure
 func (cd *ColumnDataDouble) PinToC(p *runtime.Pinner, h HandleType) (unsafe.Pointer, func()) {
 	if len(cd.xs) == 0 {
 		return nil, func() {}
@@ -287,12 +288,18 @@ func (cd *ColumnDataDouble) PinToC(p *runtime.Pinner, h HandleType) (unsafe.Poin
 
 // NewColumnDataDouble wraps float64 slice.
 // Args:
-//   xs: values to wrap
+//
+//	xs: values to wrap
+//
 // Returns:
-//   ColumnDataDouble: column data
+//
+//	ColumnDataDouble: column data
+//
 // Example:
-//   cd := NewColumnDataDouble(values) // → ColumnDataDouble
+//
+//	cd := NewColumnDataDouble(values) // → ColumnDataDouble
 func NewColumnDataDouble(xs []float64) ColumnDataDouble { return ColumnDataDouble{xs: xs} }
+
 func newColumnDataDoubleFromNative(
 	name string, xs C.qdb_exp_batch_push_column_t, n int,
 ) (ColumnDataDouble, error) {
@@ -312,14 +319,20 @@ func newColumnDataDoubleFromNative(
 	}
 	return NewColumnDataDouble(goSlice), nil
 }
+
 // GetColumnDataDouble extracts float64 values.
 // Args:
-//   cd: column data
+//
+//	cd: column data
+//
 // Returns:
-//   []float64: values
-//   error: if wrong type
+//
+//	[]float64: values
+//	error: if wrong type
+//
 // Example:
-//   vals, err := GetColumnDataDouble(cd) // → []float64
+//
+//	vals, err := GetColumnDataDouble(cd) // → []float64
 func GetColumnDataDouble(cd ColumnData) ([]float64, error) {
 	v, ok := cd.(*ColumnDataDouble)
 	if !ok {
@@ -327,13 +340,19 @@ func GetColumnDataDouble(cd ColumnData) ([]float64, error) {
 	}
 	return v.xs, nil
 }
+
 // GetColumnDataDoubleUnsafe extracts values unsafely.
 // Args:
-//   cd: column data
+//
+//	cd: column data
+//
 // Returns:
-//   []float64: values
+//
+//	[]float64: values
+//
 // Example:
-//   vals := GetColumnDataDoubleUnsafe(cd) // → []float64
+//
+//	vals := GetColumnDataDoubleUnsafe(cd) // → []float64
 func GetColumnDataDoubleUnsafe(cd ColumnData) []float64 {
 	return (*ColumnDataDouble)(ifaceDataPtr(cd)).xs
 }
@@ -380,8 +399,9 @@ func (cd *ColumnDataTimestamp) appendDataUnsafe(d ColumnData) {
 }
 
 // PinToC exposes the Go slice to C without copying:
-//   – pins the slice base so it stays immovable
-//   – returns a no-op release closure
+//
+//	– pins the slice base so it stays immovable
+//	– returns a no-op release closure
 func (cd *ColumnDataTimestamp) PinToC(p *runtime.Pinner, h HandleType) (unsafe.Pointer, func()) {
 	if len(cd.xs) == 0 {
 		return nil, func() {}
@@ -442,12 +462,17 @@ func newColumnDataTimestampFromNative(
 
 // GetColumnDataTimestamp extracts time values.
 // Args:
-//   cd: column data
+//
+//	cd: column data
+//
 // Returns:
-//   []time.Time: timestamps
-//   error: if wrong type
+//
+//	[]time.Time: timestamps
+//	error: if wrong type
+//
 // Example:
-//   times, err := GetColumnDataTimestamp(cd) // → []time.Time
+//
+//	times, err := GetColumnDataTimestamp(cd) // → []time.Time
 func GetColumnDataTimestamp(cd ColumnData) ([]time.Time, error) {
 	xs, err := GetColumnDataTimestampNative(cd)
 	if err != nil {
@@ -459,12 +484,17 @@ func GetColumnDataTimestamp(cd ColumnData) ([]time.Time, error) {
 
 // GetColumnDataTimestampNative extracts native times.
 // Args:
-//   cd: column data
+//
+//	cd: column data
+//
 // Returns:
-//   []C.qdb_timespec_t: native times
-//   error: if wrong type
+//
+//	[]C.qdb_timespec_t: native times
+//	error: if wrong type
+//
 // Example:
-//   specs, err := GetColumnDataTimestampNative(cd) // → []timespec
+//
+//	specs, err := GetColumnDataTimestampNative(cd) // → []timespec
 func GetColumnDataTimestampNative(cd ColumnData) ([]C.qdb_timespec_t, error) {
 	v, ok := cd.(*ColumnDataTimestamp)
 	if !ok {
@@ -475,22 +505,32 @@ func GetColumnDataTimestampNative(cd ColumnData) ([]C.qdb_timespec_t, error) {
 
 // GetColumnDataTimestampUnsafe extracts times unsafely.
 // Args:
-//   cd: column data
+//
+//	cd: column data
+//
 // Returns:
-//   []time.Time: timestamps
+//
+//	[]time.Time: timestamps
+//
 // Example:
-//   times := GetColumnDataTimestampUnsafe(cd) // → []time.Time
+//
+//	times := GetColumnDataTimestampUnsafe(cd) // → []time.Time
 func GetColumnDataTimestampUnsafe(cd ColumnData) []time.Time {
 	return QdbTimespecSliceToTime(GetColumnDataTimestampNativeUnsafe(cd))
 }
 
 // GetColumnDataTimestampNativeUnsafe extracts native unsafely.
 // Args:
-//   cd: column data
+//
+//	cd: column data
+//
 // Returns:
-//   []C.qdb_timespec_t: native times
+//
+//	[]C.qdb_timespec_t: native times
+//
 // Example:
-//   specs := GetColumnDataTimestampNativeUnsafe(cd) // → []timespec
+//
+//	specs := GetColumnDataTimestampNativeUnsafe(cd) // → []timespec
 func GetColumnDataTimestampNativeUnsafe(cd ColumnData) []C.qdb_timespec_t {
 	return (*ColumnDataTimestamp)(ifaceDataPtr(cd)).xs
 }
@@ -539,8 +579,9 @@ func (cd *ColumnDataBlob) appendDataUnsafe(d ColumnData) {
 // PinToC builds a C envelope and pins each []byte in cd.xs.
 //
 // Decision rationale:
-//   – Zero-copy path avoids duplicating potentially large blobs.
-//   – release() frees only the envelope; Go memory is unpinned automatically.
+//
+//	– Zero-copy path avoids duplicating potentially large blobs.
+//	– release() frees only the envelope; Go memory is unpinned automatically.
 func (cd *ColumnDataBlob) PinToC(p *runtime.Pinner, h HandleType) (unsafe.Pointer, func()) {
 	count := len(cd.xs)
 	if count == 0 {
@@ -558,8 +599,8 @@ func (cd *ColumnDataBlob) PinToC(p *runtime.Pinner, h HandleType) (unsafe.Pointe
 	// Point each qdb_blob_t to pinned Go byte slices (zero-copy)
 	for i, b := range cd.xs {
 		if len(b) > 0 {
-			p.Pin(&b[0])                               // keep backing array immovable
-			slice[i].content = unsafe.Pointer(&b[0])   // direct pointer into Go memory
+			p.Pin(&b[0])                             // keep backing array immovable
+			slice[i].content = unsafe.Pointer(&b[0]) // direct pointer into Go memory
 			slice[i].content_length = C.qdb_size_t(len(b))
 		}
 	}
@@ -574,12 +615,18 @@ func (cd *ColumnDataBlob) PinToC(p *runtime.Pinner, h HandleType) (unsafe.Pointe
 
 // NewColumnDataBlob wraps blob slice.
 // Args:
-//   xs: binary values
+//
+//	xs: binary values
+//
 // Returns:
-//   ColumnDataBlob: column data
+//
+//	ColumnDataBlob: column data
+//
 // Example:
-//   cd := NewColumnDataBlob(blobs) // → ColumnDataBlob
+//
+//	cd := NewColumnDataBlob(blobs) // → ColumnDataBlob
 func NewColumnDataBlob(xs [][]byte) ColumnDataBlob { return ColumnDataBlob{xs: xs} }
+
 func newColumnDataBlobFromNative(
 	name string, xs C.qdb_exp_batch_push_column_t, n int,
 ) (ColumnDataBlob, error) {
@@ -603,14 +650,20 @@ func newColumnDataBlobFromNative(
 	}
 	return NewColumnDataBlob(out), nil
 }
+
 // GetColumnDataBlob extracts blob values.
 // Args:
-//   cd: column data
+//
+//	cd: column data
+//
 // Returns:
-//   [][]byte: blobs
-//   error: if wrong type
+//
+//	[][]byte: blobs
+//	error: if wrong type
+//
 // Example:
-//   blobs, err := GetColumnDataBlob(cd) // → [][]byte
+//
+//	blobs, err := GetColumnDataBlob(cd) // → [][]byte
 func GetColumnDataBlob(cd ColumnData) ([][]byte, error) {
 	v, ok := cd.(*ColumnDataBlob)
 	if !ok {
@@ -618,13 +671,19 @@ func GetColumnDataBlob(cd ColumnData) ([][]byte, error) {
 	}
 	return v.xs, nil
 }
+
 // GetColumnDataBlobUnsafe extracts blobs unsafely.
 // Args:
-//   cd: column data
+//
+//	cd: column data
+//
 // Returns:
-//   [][]byte: blobs
+//
+//	[][]byte: blobs
+//
 // Example:
-//   blobs := GetColumnDataBlobUnsafe(cd) // → [][]byte
+//
+//	blobs := GetColumnDataBlobUnsafe(cd) // → [][]byte
 func GetColumnDataBlobUnsafe(cd ColumnData) [][]byte {
 	return (*ColumnDataBlob)(ifaceDataPtr(cd)).xs
 }
@@ -673,54 +732,61 @@ func (cd *ColumnDataString) appendDataUnsafe(d ColumnData) {
 // PinToC builds a C envelope and pins each string in cd.xs.
 //
 // Decision rationale:
-//   – Zero-copy path avoids duplicating potentially large strings.
-//   – qdb_string_t uses explicit length, so NUL-termination is not required.
+//
+//	– Zero-copy path avoids duplicating potentially large strings.
+//	– qdb_string_t uses explicit length, so NUL-termination is not required.
 func (cd *ColumnDataString) PinToC(p *runtime.Pinner, h HandleType) (unsafe.Pointer, func()) {
-    count := len(cd.xs)
-    if count == 0 {
-        // still return a valid no-op release func
-        return nil, func() {}
-    }
+	count := len(cd.xs)
+	if count == 0 {
+		// still return a valid no-op release func
+		return nil, func() {}
+	}
 
-    // Allocate the C envelope once
-    arr, err := qdbAllocBuffer[C.qdb_string_t](h, count)
-    if err != nil {
-        panic(err)
-    }
-    slice := unsafe.Slice(arr, count)
+	// Allocate the C envelope once
+	arr, err := qdbAllocBuffer[C.qdb_string_t](h, count)
+	if err != nil {
+		panic(err)
+	}
+	slice := unsafe.Slice(arr, count)
 
-    // Fill the envelope with zero-copy, pinned Go strings
-    for i := 0; i < count; i++ {
-        s := &cd.xs[i]
-        if len(*s) == 0 {
-            continue // leave data/length = 0
-        }
+	// Fill the envelope with zero-copy, pinned Go strings
+	for i := 0; i < count; i++ {
+		s := &cd.xs[i]
+		if len(*s) == 0 {
+			continue // leave data/length = 0
+		}
 
-        // qdb_string_t already carries an explicit length, therefore no
-        // NUL-terminator is required.  We simply obtain the address of the
-        // existing Go string bytes, pin that memory so the GC can’t move it,
-        // and store the pointer/length in the envelope.
-        dataPtr := unsafe.StringData(*s)      // pointer to first byte
-        p.Pin(dataPtr)                        // keep the bytes immovable
+		// qdb_string_t already carries an explicit length, therefore no
+		// NUL-terminator is required.  We simply obtain the address of the
+		// existing Go string bytes, pin that memory so the GC can’t move it,
+		// and store the pointer/length in the envelope.
+		dataPtr := unsafe.StringData(*s) // pointer to first byte
+		p.Pin(dataPtr)                   // keep the bytes immovable
 
-        slice[i].data   = (*C.char)(unsafe.Pointer(dataPtr))
-        slice[i].length = C.qdb_size_t(len(*s))
-    }
+		slice[i].data = (*C.char)(unsafe.Pointer(dataPtr))
+		slice[i].length = C.qdb_size_t(len(*s))
+	}
 
-    // envelope itself must be freed after the C call
-    release := func() { qdbRelease(h, arr) }
+	// envelope itself must be freed after the C call
+	release := func() { qdbRelease(h, arr) }
 
-    return unsafe.Pointer(arr), release
+	return unsafe.Pointer(arr), release
 }
 
 // NewColumnDataString wraps string slice.
 // Args:
-//   xs: string values
+//
+//	xs: string values
+//
 // Returns:
-//   ColumnDataString: column data
+//
+//	ColumnDataString: column data
+//
 // Example:
-//   cd := NewColumnDataString(strs) // → ColumnDataString
+//
+//	cd := NewColumnDataString(strs) // → ColumnDataString
 func NewColumnDataString(xs []string) ColumnDataString { return ColumnDataString{xs: xs} }
+
 func newColumnDataStringFromNative(
 	name string, xs C.qdb_exp_batch_push_column_t, n int,
 ) (ColumnDataString, error) {
@@ -744,14 +810,20 @@ func newColumnDataStringFromNative(
 	}
 	return NewColumnDataString(out), nil
 }
+
 // GetColumnDataString extracts string values.
 // Args:
-//   cd: column data
+//
+//	cd: column data
+//
 // Returns:
-//   []string: strings
-//   error: if wrong type
+//
+//	[]string: strings
+//	error: if wrong type
+//
 // Example:
-//   strs, err := GetColumnDataString(cd) // → []string
+//
+//	strs, err := GetColumnDataString(cd) // → []string
 func GetColumnDataString(cd ColumnData) ([]string, error) {
 	v, ok := cd.(*ColumnDataString)
 	if !ok {
@@ -759,13 +831,19 @@ func GetColumnDataString(cd ColumnData) ([]string, error) {
 	}
 	return v.xs, nil
 }
+
 // GetColumnDataStringUnsafe extracts strings unsafely.
 // Args:
-//   cd: column data
+//
+//	cd: column data
+//
 // Returns:
-//   []string: strings
+//
+//	[]string: strings
+//
 // Example:
-//   strs := GetColumnDataStringUnsafe(cd) // → []string
+//
+//	strs := GetColumnDataStringUnsafe(cd) // → []string
 func GetColumnDataStringUnsafe(cd ColumnData) []string {
 	return (*ColumnDataString)(ifaceDataPtr(cd)).xs
 }

--- a/direct.go
+++ b/direct.go
@@ -5,6 +5,7 @@ package qdb
 	#include <stdlib.h>
 */
 import "C"
+
 import (
 	"fmt"
 	"time"
@@ -79,6 +80,7 @@ func (h DirectHandleType) Integer(alias string) DirectIntegerEntry {
 }
 
 // PrefixGet : Retrieves the list of all entries matching the provided prefix.
+//
 //	A prefix-based search will enable you to find all entries matching a provided prefix.
 //	This function returns the list of aliases. It’s up to the user to query the content associated with every entry, if needed.
 func (h DirectHandleType) PrefixGet(prefix string, limit int) ([]string, error) {
@@ -179,6 +181,7 @@ func (e DirectIntegerEntry) Get() (int64, error) {
 }
 
 // Put creates a new signed 64-bit integer.
+//
 //	Atomically creates an entry of the given alias and sets it to a cross-platform signed 64-bit integer.
 //	If the entry already exists, the function returns an error.
 //
@@ -194,6 +197,7 @@ func (e DirectIntegerEntry) Put(content int64, expiry time.Time) error {
 }
 
 // Update creates or updates a signed 64-bit integer.
+//
 //	Atomically updates an entry of the given alias to the provided value.
 //	If the entry doesn’t exist, it will be created.
 //
@@ -206,6 +210,7 @@ func (e DirectIntegerEntry) Update(newContent int64, expiry time.Time) error {
 }
 
 // Add : Atomically increases or decreases a signed 64-bit integer.
+//
 //	The specified entry will be atomically increased (or decreased) according to the given addend value:
 //		To increase the value, specify a positive added
 //		To decrease the value, specify a negative added

--- a/direct.go
+++ b/direct.go
@@ -102,7 +102,7 @@ func (h DirectHandleType) PrefixGet(prefix string, limit int) ([]string, error) 
 		}
 		return output, nil
 	}
-	return []string{}, ErrorType(err)
+	return []string{}, wrapError(err, "direct_prefix_get", "prefix", prefix, "limit", limit)
 }
 
 // Alias returns an alias name
@@ -122,7 +122,7 @@ func (e DirectEntry) Remove() error {
 	alias := convertToCharStar(e.alias)
 	defer releaseCharStar(alias)
 	err := C.qdb_direct_remove(e.handle, alias)
-	return makeErrorOrNil(err)
+	return wrapError(err, "direct_remove", "alias", e.alias)
 }
 
 // Get returns an entry's contents
@@ -137,7 +137,7 @@ func (e DirectBlobEntry) Get() ([]byte, error) {
 	err := C.qdb_direct_blob_get(e.handle, alias, &content, &contentLength)
 
 	output := C.GoBytes(content, C.int(contentLength))
-	return output, makeErrorOrNil(err)
+	return output, wrapError(err, "direct_blob_get", "alias", e.alias)
 }
 
 // Put creates a new entry and sets its content to the provided blob
@@ -152,7 +152,7 @@ func (e DirectBlobEntry) Put(content []byte, expiry time.Time) error {
 		contentPtr = unsafe.Pointer(&content[0])
 	}
 	err := C.qdb_direct_blob_put(e.handle, alias, contentPtr, contentSize, toQdbTime(expiry))
-	return makeErrorOrNil(err)
+	return wrapError(err, "direct_blob_put", "alias", e.alias, "content_size", len(content))
 }
 
 // Update creates or updates an entry and sets its content to the provided blob.
@@ -167,7 +167,7 @@ func (e *DirectBlobEntry) Update(newContent []byte, expiry time.Time) error {
 		contentPtr = unsafe.Pointer(&newContent[0])
 	}
 	err := C.qdb_direct_blob_update(e.handle, alias, contentPtr, contentSize, toQdbTime(expiry))
-	return makeErrorOrNil(err)
+	return wrapError(err, "direct_blob_update", "alias", e.alias, "content_size", len(newContent))
 }
 
 // Get returns the value of a signed 64-bit integer
@@ -177,7 +177,7 @@ func (e DirectIntegerEntry) Get() (int64, error) {
 	var content C.qdb_int_t
 	err := C.qdb_direct_int_get(e.handle, alias, &content)
 	output := int64(content)
-	return output, makeErrorOrNil(err)
+	return output, wrapError(err, "direct_int_get", "alias", e.alias)
 }
 
 // Put creates a new signed 64-bit integer.
@@ -193,7 +193,7 @@ func (e DirectIntegerEntry) Put(content int64, expiry time.Time) error {
 	alias := convertToCharStar(e.alias)
 	defer releaseCharStar(alias)
 	err := C.qdb_direct_int_put(e.handle, alias, C.qdb_int_t(content), toQdbTime(expiry))
-	return makeErrorOrNil(err)
+	return wrapError(err, "direct_int_put", "alias", e.alias, "content", content)
 }
 
 // Update creates or updates a signed 64-bit integer.
@@ -206,7 +206,7 @@ func (e DirectIntegerEntry) Update(newContent int64, expiry time.Time) error {
 	alias := convertToCharStar(e.alias)
 	defer releaseCharStar(alias)
 	err := C.qdb_direct_int_update(e.handle, alias, C.qdb_int_t(newContent), toQdbTime(expiry))
-	return makeErrorOrNil(err)
+	return wrapError(err, "direct_int_update", "alias", e.alias, "content", newContent)
 }
 
 // Add : Atomically increases or decreases a signed 64-bit integer.
@@ -223,5 +223,5 @@ func (e DirectIntegerEntry) Add(added int64) (int64, error) {
 	var result C.qdb_int_t
 	err := C.qdb_direct_int_add(e.handle, alias, C.qdb_int_t(added), &result)
 	output := int64(result)
-	return output, makeErrorOrNil(err)
+	return output, wrapError(err, "direct_int_add", "alias", e.alias, "added", added)
 }

--- a/direct_test.go
+++ b/direct_test.go
@@ -2,6 +2,7 @@ package qdb
 
 import (
 	"testing"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/entry.go
+++ b/entry.go
@@ -34,7 +34,7 @@ func (e Entry) Remove() error {
 	alias := convertToCharStar(e.alias)
 	defer releaseCharStar(alias)
 	err := C.qdb_remove(e.handle, alias)
-	return makeErrorOrNil(err)
+	return wrapError(err, "entry_remove", "alias", e.alias)
 }
 
 // ::: EXPIRY RELATED FUNCTIONS :::
@@ -52,7 +52,7 @@ func (e Entry) ExpiresAt(expiry time.Time) error {
 	alias := convertToCharStar(e.alias)
 	defer releaseCharStar(alias)
 	err := C.qdb_expires_at(e.handle, alias, toQdbTime(expiry))
-	return makeErrorOrNil(err)
+	return wrapError(err, "entry_expires_at", "alias", e.alias)
 }
 
 // ExpiresFromNow : Sets the expiration time of an entry, relative to the current time of the client.
@@ -65,7 +65,7 @@ func (e Entry) ExpiresFromNow(expiry time.Duration) error {
 	alias := convertToCharStar(e.alias)
 	defer releaseCharStar(alias)
 	err := C.qdb_expires_from_now(e.handle, alias, C.qdb_time_t(expiry/time.Millisecond))
-	return makeErrorOrNil(err)
+	return wrapError(err, "entry_expires_from_now", "alias", e.alias, "expiry_ms", expiry/time.Millisecond)
 }
 
 // ::: END OF EXPIRY RELATED FUNCTIONS :::
@@ -131,7 +131,7 @@ func (e Entry) GetMetadata() (Metadata, error) {
 	defer releaseCharStar(alias)
 	var m C.qdb_entry_metadata_t
 	err := C.qdb_get_metadata(e.handle, alias, &m)
-	return Metadata{RefID(m.reference), EntryType(m._type), uint64(m.size), TimespecToStructG(m.modification_time), TimespecToStructG(m.expiry_time)}, makeErrorOrNil(err)
+	return Metadata{RefID(m.reference), EntryType(m._type), uint64(m.size), TimespecToStructG(m.modification_time), TimespecToStructG(m.expiry_time)}, wrapError(err, "entry_get_metadata", "alias", e.alias)
 }
 
 // Exists : Returns true if the entry exists

--- a/entry.go
+++ b/entry.go
@@ -5,6 +5,7 @@ package qdb
 	#include <stdlib.h>
 */
 import "C"
+
 import (
 	"time"
 	"unsafe"

--- a/entry_blob.go
+++ b/entry_blob.go
@@ -6,6 +6,7 @@ package qdb
 	#include <stdlib.h>
 */
 import "C"
+
 import (
 	"time"
 	"unsafe"
@@ -17,6 +18,7 @@ type BlobEntry struct {
 }
 
 // Get : Retrieve an entry's content
+//
 //	If the entry does not exist, the function will fail and return 'alias not found' error.
 func (entry BlobEntry) Get() ([]byte, error) {
 	alias := convertToCharStar(entry.alias)
@@ -31,6 +33,7 @@ func (entry BlobEntry) Get() ([]byte, error) {
 }
 
 // GetAndRemove : Atomically gets an entry from the quasardb server and removes it.
+//
 //	If the entry does not exist, the function will fail and return 'alias not found' error.
 func (entry BlobEntry) GetAndRemove() ([]byte, error) {
 	var content unsafe.Pointer
@@ -45,6 +48,7 @@ func (entry BlobEntry) GetAndRemove() ([]byte, error) {
 }
 
 // Put : Creates a new entry and sets its content to the provided blob.
+//
 //	If the entry already exists the function will fail and will return 'alias already exists' error.
 //	You can specify an expiry or use NeverExpires if you don’t want the entry to expire.
 func (entry BlobEntry) Put(content []byte, expiry time.Time) error {
@@ -60,6 +64,7 @@ func (entry BlobEntry) Put(content []byte, expiry time.Time) error {
 }
 
 // Update : Creates or updates an entry and sets its content to the provided blob.
+//
 //	If the entry already exists, the function will modify the entry.
 //	You can specify an expiry or use NeverExpires if you don’t want the entry to expire.
 func (entry *BlobEntry) Update(newContent []byte, expiry time.Time) error {
@@ -75,6 +80,7 @@ func (entry *BlobEntry) Update(newContent []byte, expiry time.Time) error {
 }
 
 // GetAndUpdate : Atomically gets and updates (in this order) the entry on the quasardb server.
+//
 //	The entry must already exist.
 func (entry *BlobEntry) GetAndUpdate(newContent []byte, expiry time.Time) ([]byte, error) {
 	alias := convertToCharStar(entry.alias)
@@ -93,10 +99,11 @@ func (entry *BlobEntry) GetAndUpdate(newContent []byte, expiry time.Time) ([]byt
 }
 
 // CompareAndSwap : Atomically compares the entry with comparand and updates it to new_value if, and only if, they match.
+//
 //	The function returns the original value of the entry in case of a mismatch. When it matches, no content is returned.
 //	The entry must already exist.
 //	Update will occur if and only if the content of the entry matches bit for bit the content of the comparand buffer.
-func (entry *BlobEntry) CompareAndSwap(newValue []byte, newComparand []byte, expiry time.Time) ([]byte, error) {
+func (entry *BlobEntry) CompareAndSwap(newValue, newComparand []byte, expiry time.Time) ([]byte, error) {
 	alias := convertToCharStar(entry.alias)
 	defer releaseCharStar(alias)
 	valueLength := C.qdb_size_t(len(newValue))
@@ -118,6 +125,7 @@ func (entry *BlobEntry) CompareAndSwap(newValue []byte, newComparand []byte, exp
 }
 
 // RemoveIf : Atomically removes the entry on the server if the content matches.
+//
 //	The entry must already exist.
 //	Removal will occur if and only if the content of the entry matches bit for bit the content of the comparand buffer.
 func (entry BlobEntry) RemoveIf(comparand []byte) error {
@@ -133,10 +141,11 @@ func (entry BlobEntry) RemoveIf(comparand []byte) error {
 }
 
 // GetNoAlloc : Retrieve an entry's content to already allocated buffer
+//
 //	If the entry does not exist, the function will fail and return 'alias not found' error.
 //	If the buffer is not large enough to hold the data, the function will fail
 //	and return `buffer is too small`, content length will nevertheless be
-// 	returned with entry size so that the caller may resize its buffer and try again.
+//	returned with entry size so that the caller may resize its buffer and try again.
 func (entry BlobEntry) GetNoAlloc(content []byte) (int, error) {
 	alias := convertToCharStar(entry.alias)
 	defer releaseCharStar(alias)

--- a/entry_blob.go
+++ b/entry_blob.go
@@ -29,7 +29,7 @@ func (entry BlobEntry) Get() ([]byte, error) {
 	err := C.qdb_blob_get(entry.handle, alias, &content, &contentLength)
 
 	output := C.GoBytes(content, C.int(contentLength))
-	return output, makeErrorOrNil(err)
+	return output, wrapError(err, "blob_get", "alias", entry.alias)
 }
 
 // GetAndRemove : Atomically gets an entry from the quasardb server and removes it.
@@ -44,7 +44,7 @@ func (entry BlobEntry) GetAndRemove() ([]byte, error) {
 	err := C.qdb_blob_get_and_remove(entry.handle, alias, &content, &contentLength)
 
 	output := C.GoBytes(unsafe.Pointer(content), C.int(contentLength))
-	return output, makeErrorOrNil(err)
+	return output, wrapError(err, "blob_get_and_remove", "alias", entry.alias)
 }
 
 // Put : Creates a new entry and sets its content to the provided blob.
@@ -60,7 +60,7 @@ func (entry BlobEntry) Put(content []byte, expiry time.Time) error {
 		contentPtr = unsafe.Pointer(&content[0])
 	}
 	err := C.qdb_blob_put(entry.handle, alias, contentPtr, contentSize, toQdbTime(expiry))
-	return makeErrorOrNil(err)
+	return wrapError(err, "blob_put", "alias", entry.alias, "size", len(content), "expiry", expiry)
 }
 
 // Update : Creates or updates an entry and sets its content to the provided blob.
@@ -76,7 +76,7 @@ func (entry *BlobEntry) Update(newContent []byte, expiry time.Time) error {
 		contentPtr = unsafe.Pointer(&newContent[0])
 	}
 	err := C.qdb_blob_update(entry.handle, alias, contentPtr, contentSize, toQdbTime(expiry))
-	return makeErrorOrNil(err)
+	return wrapError(err, "blob_update", "alias", entry.alias, "size", len(newContent), "expiry", expiry)
 }
 
 // GetAndUpdate : Atomically gets and updates (in this order) the entry on the quasardb server.
@@ -95,7 +95,7 @@ func (entry *BlobEntry) GetAndUpdate(newContent []byte, expiry time.Time) ([]byt
 	defer entry.Release(content)
 	err := C.qdb_blob_get_and_update(entry.handle, alias, contentPtr, contentSize, toQdbTime(expiry), &content, &contentLength)
 	output := C.GoBytes(unsafe.Pointer(content), C.int(contentLength))
-	return output, makeErrorOrNil(err)
+	return output, wrapError(err, "blob_get_and_update", "alias", entry.alias, "content_size", len(newContent))
 }
 
 // CompareAndSwap : Atomically compares the entry with comparand and updates it to new_value if, and only if, they match.
@@ -121,7 +121,7 @@ func (entry *BlobEntry) CompareAndSwap(newValue, newComparand []byte, expiry tim
 	defer entry.Release(unsafe.Pointer(originalValue))
 	err := C.qdb_blob_compare_and_swap(entry.handle, alias, value, valueLength, comparand, comparandLength, toQdbTime(expiry), &originalValue, &originalLength)
 	output := C.GoBytes(originalValue, C.int(originalLength))
-	return output, makeErrorOrNil(err)
+	return output, wrapError(err, "blob_compare_and_swap", "alias", entry.alias, "comparand_size", len(newComparand), "new_size", len(newValue), "expiry", expiry)
 }
 
 // RemoveIf : Atomically removes the entry on the server if the content matches.
@@ -137,7 +137,7 @@ func (entry BlobEntry) RemoveIf(comparand []byte) error {
 		comparandC = unsafe.Pointer(&comparand[0])
 	}
 	err := C.qdb_blob_remove_if(entry.handle, alias, comparandC, comparandLength)
-	return makeErrorOrNil(err)
+	return wrapError(err, "blob_remove_if", "alias", entry.alias, "comparand_size", len(comparand))
 }
 
 // GetNoAlloc : Retrieve an entry's content to already allocated buffer
@@ -157,5 +157,5 @@ func (entry BlobEntry) GetNoAlloc(content []byte) (int, error) {
 
 	err := C.qdb_blob_get_noalloc(entry.handle, alias, contentPtr, &contentLength)
 
-	return int(contentLength), makeErrorOrNil(err)
+	return int(contentLength), wrapError(err, "blob_get_length", "alias", entry.alias)
 }

--- a/entry_integer.go
+++ b/entry_integer.go
@@ -5,6 +5,7 @@ package qdb
 	#include <stdlib.h>
 */
 import "C"
+
 import (
 	"time"
 )
@@ -15,6 +16,7 @@ type IntegerEntry struct {
 }
 
 // Put : Creates a new signed 64-bit integer.
+//
 //	Atomically creates an entry of the given alias and sets it to a cross-platform signed 64-bit integer.
 //	If the entry already exists, the function returns an error.
 //
@@ -30,6 +32,7 @@ func (entry IntegerEntry) Put(content int64, expiry time.Time) error {
 }
 
 // Update : Creates or updates a signed 64-bit integer.
+//
 //	Atomically updates an entry of the given alias to the provided value.
 //	If the entry doesn’t exist, it will be created.
 //
@@ -42,6 +45,7 @@ func (entry *IntegerEntry) Update(newContent int64, expiry time.Time) error {
 }
 
 // Get : Atomically retrieves the value of a signed 64-bit integer.
+//
 //	Atomically retrieves the value of an existing 64-bit integer.
 func (entry IntegerEntry) Get() (int64, error) {
 	alias := convertToCharStar(entry.alias)
@@ -53,6 +57,7 @@ func (entry IntegerEntry) Get() (int64, error) {
 }
 
 // Add : Atomically increases or decreases a signed 64-bit integer.
+//
 //	The specified entry will be atomically increased (or decreased) according to the given addend value:
 //		To increase the value, specify a positive added
 //		To decrease the value, specify a negative added

--- a/entry_integer.go
+++ b/entry_integer.go
@@ -28,7 +28,7 @@ func (entry IntegerEntry) Put(content int64, expiry time.Time) error {
 	alias := convertToCharStar(entry.alias)
 	defer releaseCharStar(alias)
 	err := C.qdb_int_put(entry.handle, alias, C.qdb_int_t(content), toQdbTime(expiry))
-	return makeErrorOrNil(err)
+	return wrapError(err, "integer_put", "alias", entry.alias, "value", content, "expiry", expiry)
 }
 
 // Update : Creates or updates a signed 64-bit integer.
@@ -41,7 +41,7 @@ func (entry *IntegerEntry) Update(newContent int64, expiry time.Time) error {
 	alias := convertToCharStar(entry.alias)
 	defer releaseCharStar(alias)
 	err := C.qdb_int_update(entry.handle, alias, C.qdb_int_t(newContent), toQdbTime(expiry))
-	return makeErrorOrNil(err)
+	return wrapError(err, "integer_update", "alias", entry.alias, "value", newContent, "expiry", expiry)
 }
 
 // Get : Atomically retrieves the value of a signed 64-bit integer.
@@ -53,7 +53,7 @@ func (entry IntegerEntry) Get() (int64, error) {
 	var content C.qdb_int_t
 	err := C.qdb_int_get(entry.handle, alias, &content)
 	output := int64(content)
-	return output, makeErrorOrNil(err)
+	return output, wrapError(err, "integer_get", "alias", entry.alias)
 }
 
 // Add : Atomically increases or decreases a signed 64-bit integer.
@@ -70,5 +70,5 @@ func (entry IntegerEntry) Add(added int64) (int64, error) {
 	var result C.qdb_int_t
 	err := C.qdb_int_add(entry.handle, alias, C.qdb_int_t(added), &result)
 	output := int64(result)
-	return output, makeErrorOrNil(err)
+	return output, wrapError(err, "integer_add", "alias", entry.alias, "addend", added)
 }

--- a/entry_integer_test.go
+++ b/entry_integer_test.go
@@ -8,98 +8,98 @@ import (
 )
 
 func TestIntegerPut(t *testing.T) {
-    handle := newTestHandle(t)
-    defer handle.Close()
+	handle := newTestHandle(t)
+	defer handle.Close()
 
-    alias := generateAlias(16)
-    integer := handle.Integer(alias)
-    defer integer.Remove()
+	alias := generateAlias(16)
+	integer := handle.Integer(alias)
+	defer integer.Remove()
 
-    content := int64(13)
-    err := integer.Put(content, NeverExpires())
-    assert.NoError(t, err)
+	content := int64(13)
+	err := integer.Put(content, NeverExpires())
+	assert.NoError(t, err)
 }
 
 func TestIntegerPutAgain(t *testing.T) {
-    handle := newTestHandle(t)
-    defer handle.Close()
+	handle := newTestHandle(t)
+	defer handle.Close()
 
-    alias := generateAlias(16)
-    integer := handle.Integer(alias)
-    defer integer.Remove()
+	alias := generateAlias(16)
+	integer := handle.Integer(alias)
+	defer integer.Remove()
 
-    content := int64(13)
-    require.NoError(t, integer.Put(content, NeverExpires()))
-    err := integer.Put(content, NeverExpires())
-    assert.Error(t, err)
+	content := int64(13)
+	require.NoError(t, integer.Put(content, NeverExpires()))
+	err := integer.Put(content, NeverExpires())
+	assert.Error(t, err)
 }
 
 func TestIntegerUpdate(t *testing.T) {
-    handle := newTestHandle(t)
-    defer handle.Close()
+	handle := newTestHandle(t)
+	defer handle.Close()
 
-    alias := generateAlias(16)
-    integer := handle.Integer(alias)
-    defer integer.Remove()
+	alias := generateAlias(16)
+	integer := handle.Integer(alias)
+	defer integer.Remove()
 
-    content := int64(13)
-    newContent := int64(87)
+	content := int64(13)
+	newContent := int64(87)
 
-    require.NoError(t, integer.Put(content, NeverExpires()))
-    require.NoError(t, integer.Update(newContent, NeverExpires()))
+	require.NoError(t, integer.Put(content, NeverExpires()))
+	require.NoError(t, integer.Update(newContent, NeverExpires()))
 
-    got, err := integer.Get()
-    require.NoError(t, err)
-    assert.Equal(t, newContent, got)
+	got, err := integer.Get()
+	require.NoError(t, err)
+	assert.Equal(t, newContent, got)
 }
 
 func TestIntegerGet(t *testing.T) {
-    handle := newTestHandle(t)
-    defer handle.Close()
+	handle := newTestHandle(t)
+	defer handle.Close()
 
-    alias := generateAlias(16)
-    integer := handle.Integer(alias)
-    defer integer.Remove()
+	alias := generateAlias(16)
+	integer := handle.Integer(alias)
+	defer integer.Remove()
 
-    content := int64(13)
-    require.NoError(t, integer.Put(content, NeverExpires()))
+	content := int64(13)
+	require.NoError(t, integer.Put(content, NeverExpires()))
 
-    got, err := integer.Get()
-    require.NoError(t, err)
-    assert.Equal(t, content, got)
+	got, err := integer.Get()
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
 }
 
 func TestIntegerAdd(t *testing.T) {
-    handle := newTestHandle(t)
-    defer handle.Close()
+	handle := newTestHandle(t)
+	defer handle.Close()
 
-    alias := generateAlias(16)
-    integer := handle.Integer(alias)
-    defer integer.Remove()
+	alias := generateAlias(16)
+	integer := handle.Integer(alias)
+	defer integer.Remove()
 
-    content := int64(13)
-    require.NoError(t, integer.Put(content, NeverExpires()))
+	content := int64(13)
+	require.NoError(t, integer.Put(content, NeverExpires()))
 
-    toAdd := int64(5)
-    expected := content + toAdd
+	toAdd := int64(5)
+	expected := content + toAdd
 
-    sum, err := integer.Add(toAdd)
-    require.NoError(t, err)
-    assert.Equal(t, expected, sum)
+	sum, err := integer.Add(toAdd)
+	require.NoError(t, err)
+	assert.Equal(t, expected, sum)
 }
 
 func TestIntegerRemove(t *testing.T) {
-    handle := newTestHandle(t)
-    defer handle.Close()
+	handle := newTestHandle(t)
+	defer handle.Close()
 
-    alias := generateAlias(16)
-    integer := handle.Integer(alias)
+	alias := generateAlias(16)
+	integer := handle.Integer(alias)
 
-    content := int64(13)
-    require.NoError(t, integer.Put(content, NeverExpires()))
+	content := int64(13)
+	require.NoError(t, integer.Put(content, NeverExpires()))
 
-    require.NoError(t, integer.Remove())
+	require.NoError(t, integer.Remove())
 
-    _, err := integer.Get()
-    assert.Error(t, err)
+	_, err := integer.Get()
+	assert.Error(t, err)
 }

--- a/entry_test.go
+++ b/entry_test.go
@@ -299,9 +299,9 @@ func TestEntryExistsAfterRemove(t *testing.T) {
 	alias := generateAlias(16)
 	integer := handle.Integer(alias)
 	require.NoError(t, integer.Put(42, NeverExpires()))
-	
+
 	assert.True(t, integer.Exists())
-	
+
 	require.NoError(t, integer.Remove())
 	assert.False(t, integer.Exists())
 }
@@ -335,7 +335,7 @@ func TestEntryExistsWithSpecialCharacters(t *testing.T) {
 			integer := handle.Integer(tc.alias)
 			// Should not exist initially
 			assert.False(t, integer.Exists())
-			
+
 			// Try to create entry - this may fail for some special characters
 			err := integer.Put(42, NeverExpires())
 			if err == nil {

--- a/entry_test.go
+++ b/entry_test.go
@@ -363,6 +363,7 @@ func TestEntryExistsWithDifferentEntryTypes(t *testing.T) {
 			setup: func(alias string) (Entry, error) {
 				blob := handle.Blob(alias)
 				err := blob.Put([]byte("test content"), NeverExpires())
+
 				return blob.Entry, err
 			},
 			cleanup: func(e Entry) { e.Remove() },
@@ -372,6 +373,7 @@ func TestEntryExistsWithDifferentEntryTypes(t *testing.T) {
 			setup: func(alias string) (Entry, error) {
 				integer := handle.Integer(alias)
 				err := integer.Put(42, NeverExpires())
+
 				return integer.Entry, err
 			},
 			cleanup: func(e Entry) { e.Remove() },
@@ -422,7 +424,7 @@ func TestEntryExistsConcurrentAccess(t *testing.T) {
 
 	// Test concurrent access to Exists() - should be safe
 	done := make(chan bool, 10)
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		go func() {
 			assert.True(t, integer.Exists())
 			done <- true
@@ -430,7 +432,7 @@ func TestEntryExistsConcurrentAccess(t *testing.T) {
 	}
 
 	// Wait for all goroutines
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 }

--- a/entry_timeseries_blob.go
+++ b/entry_timeseries_blob.go
@@ -5,6 +5,7 @@ package qdb
 	#include <stdlib.h>
 */
 import "C"
+
 import (
 	"math"
 	"time"

--- a/entry_timeseries_common.go
+++ b/entry_timeseries_common.go
@@ -5,6 +5,7 @@ package qdb
 	#include <stdlib.h>
 */
 import "C"
+
 import (
 	"fmt"
 	"math"
@@ -158,7 +159,8 @@ func (t TsColumnInfo) Symtable() string {
 func NewTsColumnInfo(columnName string, columnType TsColumnType) TsColumnInfo {
 	return TsColumnInfo{columnName, columnType, ""}
 }
-func NewSymbolColumnInfo(columnName string, symtableName string) TsColumnInfo {
+
+func NewSymbolColumnInfo(columnName, symtableName string) TsColumnInfo {
 	return TsColumnInfo{columnName, TsColumnSymbol, symtableName}
 }
 
@@ -525,6 +527,7 @@ func (t TsBatchColumnInfo) toStructC() C.qdb_ts_batch_column_info_t {
 func TsBatchColumnInfoToStructInfoG(t C.qdb_ts_batch_column_info_t) TsBatchColumnInfo {
 	return TsBatchColumnInfo{C.GoString(t.timeseries), C.GoString(t.column), int64(t.elements_count_hint)}
 }
+
 func tsBatchColumnInfoArrayToC(cols ...TsBatchColumnInfo) *C.qdb_ts_batch_column_info_t {
 	if len(cols) == 0 {
 		return nil
@@ -564,7 +567,7 @@ func tsBatchColumnInfoArrayToGo(columns *C.qdb_ts_batch_column_info_t, columnsCo
 }
 
 // NewTsBatchColumnInfo : Creates a new TsBatchColumnInfo
-func NewTsBatchColumnInfo(timeseries string, column string, hint int64) TsBatchColumnInfo {
+func NewTsBatchColumnInfo(timeseries, column string, hint int64) TsBatchColumnInfo {
 	return TsBatchColumnInfo{timeseries, column, hint}
 }
 

--- a/entry_timeseries_double.go
+++ b/entry_timeseries_double.go
@@ -4,6 +4,7 @@ package qdb
 	#include <qdb/ts.h>
 */
 import "C"
+
 import (
 	"math"
 	"time"

--- a/entry_timeseries_double.go
+++ b/entry_timeseries_double.go
@@ -88,7 +88,7 @@ func (column TsDoubleColumn) Insert(points ...TsDoublePoint) error {
 	contentCount := C.qdb_size_t(len(points))
 	content := doublePointArrayToC(points...)
 	err := C.qdb_ts_double_insert(column.parent.handle, alias, columnName, content, contentCount)
-	return makeErrorOrNil(err)
+	return wrapError(err, "timeseries_double_insert", "alias", column.parent.alias, "column", column.name, "points", len(points))
 }
 
 // EraseRanges : erase all points in the specified ranges
@@ -101,7 +101,7 @@ func (column TsDoubleColumn) EraseRanges(rgs ...TsRange) (uint64, error) {
 	rangesCount := C.qdb_size_t(len(rgs))
 	erasedCount := C.qdb_uint_t(0)
 	err := C.qdb_ts_erase_ranges(column.parent.handle, alias, columnName, ranges, rangesCount, &erasedCount)
-	return uint64(erasedCount), makeErrorOrNil(err)
+	return uint64(erasedCount), wrapError(err, "ts_double_erase_ranges", "alias", column.parent.alias, "column", column.name, "ranges", len(rgs))
 }
 
 // GetRanges : Retrieves blobs in the specified range of the time series column.
@@ -122,7 +122,7 @@ func (column TsDoubleColumn) GetRanges(rgs ...TsRange) ([]TsDoublePoint, error) 
 		defer column.parent.Release(unsafe.Pointer(points))
 		return doublePointArrayToGo(points, pointsCount), nil
 	}
-	return nil, ErrorType(err)
+	return nil, wrapError(err, "ts_double_get_ranges", "alias", column.parent.alias, "column", column.name, "ranges", len(rgs))
 }
 
 // TsDoubleAggregation : Aggregation of double type
@@ -235,5 +235,5 @@ func (t *TsBulk) GetDouble() (float64, error) {
 // RowSetDouble : Set double at specified index in current row
 func (t *TsBatch) RowSetDouble(index int64, value float64) error {
 	valueIndex := C.qdb_size_t(index)
-	return makeErrorOrNil(C.qdb_ts_batch_row_set_double(t.table, valueIndex, C.double(value)))
+	return wrapError(C.qdb_ts_batch_row_set_double(t.table, valueIndex, C.double(value)), "ts_batch_row_set_double", "index", valueIndex, "value", value)
 }

--- a/entry_timeseries_int64.go
+++ b/entry_timeseries_int64.go
@@ -4,6 +4,7 @@ package qdb
 	#include <qdb/ts.h>
 */
 import "C"
+
 import (
 	"math"
 	"time"

--- a/entry_timeseries_int64.go
+++ b/entry_timeseries_int64.go
@@ -88,7 +88,7 @@ func (column TsInt64Column) Insert(points ...TsInt64Point) error {
 	contentCount := C.qdb_size_t(len(points))
 	content := int64PointArrayToC(points...)
 	err := C.qdb_ts_int64_insert(column.parent.handle, alias, columnName, content, contentCount)
-	return makeErrorOrNil(err)
+	return wrapError(err, "timeseries_int64_insert", "alias", column.parent.alias, "column", column.name, "points", len(points))
 }
 
 // EraseRanges : erase all points in the specified ranges
@@ -101,7 +101,7 @@ func (column TsInt64Column) EraseRanges(rgs ...TsRange) (uint64, error) {
 	rangesCount := C.qdb_size_t(len(rgs))
 	erasedCount := C.qdb_uint_t(0)
 	err := C.qdb_ts_erase_ranges(column.parent.handle, alias, columnName, ranges, rangesCount, &erasedCount)
-	return uint64(erasedCount), makeErrorOrNil(err)
+	return uint64(erasedCount), wrapError(err, "ts_int64_erase_ranges", "alias", column.parent.alias, "column", column.name, "ranges", len(rgs))
 }
 
 // GetRanges : Retrieves int64s in the specified range of the time series column.
@@ -122,7 +122,7 @@ func (column TsInt64Column) GetRanges(rgs ...TsRange) ([]TsInt64Point, error) {
 		defer column.parent.Release(unsafe.Pointer(points))
 		return int64PointArrayToGo(points, pointsCount), nil
 	}
-	return nil, ErrorType(err)
+	return nil, wrapError(err, "ts_int64_get_ranges", "alias", column.parent.alias, "column", column.name, "ranges", len(rgs))
 }
 
 // TsInt64Aggregation : Aggregation of int64 type
@@ -220,11 +220,11 @@ func (t *TsBulk) GetInt64() (int64, error) {
 	var content C.qdb_int_t
 	err := C.qdb_ts_row_get_int64(t.table, C.qdb_size_t(t.index), &content)
 	t.index++
-	return int64(content), makeErrorOrNil(err)
+	return int64(content), wrapError(err, "ts_bulk_get_int64")
 }
 
 // RowSetInt64 : Set int64 at specified index in current row
 func (t *TsBatch) RowSetInt64(index, value int64) error {
 	valueIndex := C.qdb_size_t(index)
-	return makeErrorOrNil(C.qdb_ts_batch_row_set_int64(t.table, valueIndex, C.qdb_int_t(value)))
+	return wrapError(C.qdb_ts_batch_row_set_int64(t.table, valueIndex, C.qdb_int_t(value)), "ts_batch_row_set_int64", "index", valueIndex, "value", value)
 }

--- a/entry_timeseries_string.go
+++ b/entry_timeseries_string.go
@@ -106,7 +106,7 @@ func (column TsStringColumn) Insert(points ...TsStringPoint) error {
 	content := stringPointArrayToC(points...)
 	defer releaseStringPointArray(content, len(points))
 	err := C.qdb_ts_string_insert(column.parent.handle, alias, columnName, content, contentCount)
-	return makeErrorOrNil(err)
+	return wrapError(err, "timeseries_string_insert", "alias", column.parent.alias, "column", column.name, "points", len(points))
 }
 
 // EraseRanges : erase all points in the specified ranges
@@ -119,7 +119,7 @@ func (column TsStringColumn) EraseRanges(rgs ...TsRange) (uint64, error) {
 	rangesCount := C.qdb_size_t(len(rgs))
 	erasedCount := C.qdb_uint_t(0)
 	err := C.qdb_ts_erase_ranges(column.parent.handle, alias, columnName, ranges, rangesCount, &erasedCount)
-	return uint64(erasedCount), makeErrorOrNil(err)
+	return uint64(erasedCount), wrapError(err, "ts_string_erase_ranges", "alias", column.parent.alias, "column", column.name, "ranges", len(rgs))
 }
 
 // GetRanges : Retrieves strings in the specified range of the time series column.
@@ -140,7 +140,7 @@ func (column TsStringColumn) GetRanges(rgs ...TsRange) ([]TsStringPoint, error) 
 		defer column.parent.Release(unsafe.Pointer(points))
 		return stringPointArrayToGo(points, pointsCount), nil
 	}
-	return nil, ErrorType(err)
+	return nil, wrapError(err, "ts_string_get_ranges", "alias", column.parent.alias, "column", column.name, "ranges", len(rgs))
 }
 
 // TsStringAggregation : Aggregation of double type
@@ -250,7 +250,7 @@ func (t *TsBulk) GetString() (string, error) {
 	err := C.qdb_ts_row_get_string(t.table, C.qdb_size_t(t.index), &content, &contentLength)
 
 	t.index++
-	return C.GoStringN(content, C.int(contentLength)), makeErrorOrNil(err)
+	return C.GoStringN(content, C.int(contentLength)), wrapError(err, "ts_bulk_get_string")
 }
 
 // RowSetString : Set string at specified index in current row
@@ -259,7 +259,7 @@ func (t *TsBatch) RowSetString(index int64, content string) error {
 	contentSize := C.qdb_size_t(len(content))
 	contentPtr := convertToCharStar(content)
 	defer releaseCharStar(contentPtr)
-	return makeErrorOrNil(C.qdb_ts_batch_row_set_string(t.table, valueIndex, contentPtr, contentSize))
+	return wrapError(C.qdb_ts_batch_row_set_string(t.table, valueIndex, contentPtr, contentSize), "ts_batch_row_set_string", "index", valueIndex, "value_size", len(content))
 }
 
 // RowSetStringNoCopy : Set string at specified index in current row without copying it
@@ -268,5 +268,5 @@ func (t *TsBatch) RowSetStringNoCopy(index int64, content string) error {
 	contentSize := C.qdb_size_t(len(content))
 	contentPtr := convertToCharStar(content)
 	defer releaseCharStar(contentPtr)
-	return makeErrorOrNil(C.qdb_ts_batch_row_set_string_no_copy(t.table, valueIndex, contentPtr, contentSize))
+	return wrapError(C.qdb_ts_batch_row_set_string_no_copy(t.table, valueIndex, contentPtr, contentSize), "ts_batch_row_set_string_no_copy", "index", valueIndex, "value_size", len(content))
 }

--- a/entry_timeseries_string.go
+++ b/entry_timeseries_string.go
@@ -5,6 +5,7 @@ package qdb
 	#include <stdlib.h>
 */
 import "C"
+
 import (
 	"math"
 	"time"
@@ -91,7 +92,7 @@ func (entry TimeseriesEntry) StringColumn(columnName string) TsStringColumn {
 }
 
 // SymbolColumn : create a column object (the symbol table name is not set)
-func (entry TimeseriesEntry) SymbolColumn(columnName string, symtableName string) TsStringColumn {
+func (entry TimeseriesEntry) SymbolColumn(columnName, symtableName string) TsStringColumn {
 	return TsStringColumn{tsColumn{NewSymbolColumnInfo(columnName, symtableName), entry}}
 }
 

--- a/entry_timeseries_timestamp.go
+++ b/entry_timeseries_timestamp.go
@@ -4,6 +4,7 @@ package qdb
 	#include <qdb/ts.h>
 */
 import "C"
+
 import (
 	"math"
 	"time"
@@ -27,7 +28,7 @@ func (t TsTimestampPoint) Content() time.Time {
 }
 
 // NewTsTimestampPoint : Create new timeseries timestamp point
-func NewTsTimestampPoint(timestamp time.Time, value time.Time) TsTimestampPoint {
+func NewTsTimestampPoint(timestamp, value time.Time) TsTimestampPoint {
 	return TsTimestampPoint{timestamp, value}
 }
 

--- a/entry_timeseries_timestamp.go
+++ b/entry_timeseries_timestamp.go
@@ -88,7 +88,7 @@ func (column TsTimestampColumn) Insert(points ...TsTimestampPoint) error {
 	contentCount := C.qdb_size_t(len(points))
 	content := timestampPointArrayToC(points...)
 	err := C.qdb_ts_timestamp_insert(column.parent.handle, alias, columnName, content, contentCount)
-	return makeErrorOrNil(err)
+	return wrapError(err, "timeseries_timestamp_insert", "alias", column.parent.alias, "column", column.name, "points", len(points))
 }
 
 // EraseRanges : erase all points in the specified ranges
@@ -101,7 +101,7 @@ func (column TsTimestampColumn) EraseRanges(rgs ...TsRange) (uint64, error) {
 	rangesCount := C.qdb_size_t(len(rgs))
 	erasedCount := C.qdb_uint_t(0)
 	err := C.qdb_ts_erase_ranges(column.parent.handle, alias, columnName, ranges, rangesCount, &erasedCount)
-	return uint64(erasedCount), makeErrorOrNil(err)
+	return uint64(erasedCount), wrapError(err, "ts_timestamp_erase_ranges", "alias", column.parent.alias, "column", column.name, "ranges", len(rgs))
 }
 
 // GetRanges : Retrieves timestamps in the specified range of the time series column.
@@ -122,7 +122,7 @@ func (column TsTimestampColumn) GetRanges(rgs ...TsRange) ([]TsTimestampPoint, e
 		defer column.parent.Release(unsafe.Pointer(points))
 		return timestampPointArrayToGo(points, pointsCount), nil
 	}
-	return nil, ErrorType(err)
+	return nil, wrapError(err, "ts_timestamp_get_ranges", "alias", column.parent.alias, "column", column.name, "ranges", len(rgs))
 }
 
 // TsTimestampAggregation : Aggregation of timestamp type
@@ -220,12 +220,12 @@ func (t *TsBulk) GetTimestamp() (time.Time, error) {
 	var content C.qdb_timespec_t
 	err := C.qdb_ts_row_get_timestamp(t.table, C.qdb_size_t(t.index), &content)
 	t.index++
-	return TimespecToStructG(content), makeErrorOrNil(err)
+	return TimespecToStructG(content), wrapError(err, "ts_bulk_get_timestamp")
 }
 
 // RowSetTimestamp : Add a timestamp to current row
 func (t *TsBatch) RowSetTimestamp(index int64, value time.Time) error {
 	valueIndex := C.qdb_size_t(index)
 	cValue := toQdbTimespec(value)
-	return makeErrorOrNil(C.qdb_ts_batch_row_set_timestamp(t.table, valueIndex, &cValue))
+	return wrapError(C.qdb_ts_batch_row_set_timestamp(t.table, valueIndex, &cValue), "ts_batch_row_set_timestamp", "index", valueIndex)
 }

--- a/error.go
+++ b/error.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2009-2025, quasardb SAS. All rights reserved.
+// Package qdb: high-performance time series database client
+// Types: ErrorType, Handle, Entry, Cluster
+// Ex: qdb.Connect(uri).GetBlob(alias) → data
 package qdb
 
 /*
@@ -6,75 +10,68 @@ package qdb
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
 
-// ErrorType obfuscating qdb_error_t
+// Error handling patterns for qdb-api-go:
+//
+// 1. Check retryability with exponential backoff:
+//
+//	err := handle.PutBlob(alias, data)
+//	for attempt := 0; err != nil && IsRetryable(err) && attempt < 3; attempt++ {
+//	    time.Sleep(time.Second * time.Duration(1<<attempt))
+//	    err = handle.PutBlob(alias, data)
+//	}
+//
+// 2. Use errors.Is() for specific error checks:
+//
+//	if errors.Is(err, qdb.ErrAliasNotFound) {
+//	    // Create new entry
+//	} else if errors.Is(err, qdb.ErrAccessDenied) {
+//	    // Handle auth failure
+//	}
+//
+// 3. Extract ErrorType from wrapped errors:
+//
+//	var qdbErr qdb.ErrorType
+//	if errors.As(err, &qdbErr) {
+//	    switch qdbErr {
+//	    case qdb.ErrTimeout:
+//	        // Handle timeout
+//	    case qdb.ErrQuotaExceeded:
+//	        // Handle quota
+//	    }
+//	}
+
+// ErrorType: QuasarDB error codes, wraps C.qdb_error_t
 type ErrorType C.qdb_error_t
 
-// Success : Success.
-// Created : Success. A new entry has been created.
-// ErrUninitialized : Uninitialized error.
-// ErrAliasNotFound : Entry alias/key was not found.
-// ErrAliasAlreadyExists : Entry alias/key already exists.
-// ErrOutOfBounds : Index out of bounds.
-// ErrSkipped : Skipped operation. Used in batches and transactions.
-// ErrIncompatibleType : Entry or column is incompatible with the operation.
-// ErrContainerEmpty : Container is empty.
-// ErrContainerFull : Container is full.
-// ErrElementNotFound : Element was not found.
-// ErrElementAlreadyExists : Element already exists.
-// ErrOverflow : Arithmetic operation overflows.
-// ErrUnderflow : Arithmetic operation underflows.
-// ErrTagAlreadySet : Tag is already set.
-// ErrTagNotSet : Tag is not set.
-// ErrTimeout : Operation timed out.
-// ErrConnectionRefused : Connection was refused.
-// ErrConnectionReset : Connection was reset.
-// ErrUnstableCluster : Cluster is unstable.
-// ErrTryAgain : Please retry.
-// ErrConflict : There is another ongoing conflicting operation.
-// ErrNotConnected : Handle is not connected.
-// ErrResourceLocked : Resource is locked.
-// ErrSystemRemote : System error on remote node (server-side). Please check errno or GetLastError() for actual error.
-// ErrSystemLocal : System error on local system (client-side). Please check errno or GetLastError() for actual error.
-// ErrInternalRemote : Internal error on remote node (server-side).
-// ErrInternalLocal : Internal error on local system (client-side).
-// ErrNoMemoryRemote : No memory on remote node (server-side).
-// ErrNoMemoryLocal : No memory on local system (client-side).
-// ErrInvalidProtocol : Protocol is invalid.
-// ErrHostNotFound : Host was not found.
-// ErrBufferTooSmall : Buffer is too small.
-// ErrNotImplemented : Operation is not implemented.
-// ErrInvalidVersion : Version is invalid.
-// ErrInvalidArgument : Argument is invalid.
-// ErrInvalidHandle : Handle is invalid.
-// ErrReservedAlias : Alias/key is reserved.
-// ErrUnmatchedContent : Content did not match.
-// ErrInvalidIterator : Iterator is invalid.
-// ErrEntryTooLarge : Entry is too large.
-// ErrTransactionPartialFailure : Transaction failed partially.
-// ErrOperationDisabled : Operation has not been enabled in cluster configuration.
-// ErrOperationNotPermitted : Operation is not permitted.
-// ErrIteratorEnd :	Iterator reached the end.
-// ErrInvalidReply : Cluster sent an invalid reply.
-// ErrNoSpaceLeft : No more space on disk.
-// ErrQuotaExceeded : Disk space quota has been reached.
-// ErrAliasTooLong : Alias is too long.
-// ErrClockSkew : Cluster nodes have important clock differences.
-// ErrAccessDenied : Access is denied.
-// ErrLoginFailed : Login failed.
-// ErrColumnNotFound : Column was not found.
-// ErrQueryTooComplex : Find is too complex.
-// ErrInvalidCryptoKey : Security key is invalid.
-// ErrInvalidQuery : Query is invalid.
-// ErrInvalidRegex : Regular expression is invalid.
-// ErrUnknownUser : Unknown user.
-// ErrInterrupted : Operation has been interrupted.
-// ErrNetworkInbufTooSmall : Network input buffer is too small to complete the operation.
-// ErrNetworkError : Network error.
-// ErrDataCorruption : Data corruption has been detected.
+// Error codes: retryable errors default true except logic/constraint/permission failures
+//
+// Network/transient (retryable):
+// - ErrTimeout: network timeout
+// - ErrConnectionRefused/Reset: connection failed
+// - ErrUnstableCluster: temporary cluster issue
+// - ErrTryAgain: explicit retry request
+// - ErrResourceLocked: concurrent access conflict
+// - ErrNetworkError: generic network failure
+//
+// Logic/programming (non-retryable):
+// - ErrInvalidArgument: bad parameter
+// - ErrIncompatibleType: type mismatch
+// - ErrInvalidQuery: malformed query
+// - ErrBufferTooSmall: insufficient buffer
+//
+// Constraints (non-retryable):
+// - ErrAliasAlreadyExists: duplicate key
+// - ErrEntryTooLarge: size limit exceeded
+// - ErrQuotaExceeded: storage quota reached
+//
+// Permissions (non-retryable):
+// - ErrAccessDenied: insufficient privileges
+// - ErrOperationNotPermitted: forbidden operation
 const (
 	Success                      ErrorType = C.qdb_e_ok
 	Created                      ErrorType = C.qdb_e_ok_created
@@ -145,11 +142,21 @@ const (
 
 func (e ErrorType) Error() string { return C.GoString(C.qdb_error(C.qdb_error_t(e))) }
 
-// Is implements Go 1.13+ error support for errors.Is() comparison
+// Is enables errors.Is() comparison for wrapped errors.
+// Returns:
+//
+//	true: target is same ErrorType
+//	false: different type
+//
+// Example:
+//
+//	errors.Is(err, qdb.ErrTimeout) // → true if timeout
 func (e ErrorType) Is(target error) bool {
-	if t, ok := target.(ErrorType); ok {
+	t, ok := target.(ErrorType)
+	if ok {
 		return e == t
 	}
+
 	return false
 }
 
@@ -157,37 +164,133 @@ func makeErrorOrNil(err C.qdb_error_t) error {
 	if err != 0 && err != C.qdb_e_ok_created {
 		return ErrorType(err)
 	}
+
 	return nil
 }
 
-// wrapError creates a contextual error from C.qdb_error_t with operation info and key-value pairs
-// Returns nil for success codes (0 and qdb_e_ok_created)
-// Example: wrapError(err, "connect", "uri", clusterURI)
+// wrapError wraps C error with context
+// In: err C.qdb_error_t, op string, kv pairs
+// Out: error with context, nil if success
+// Ex: wrapError(err, "connect", "uri", uri) → "connect (operation=connect, uri=qdb://host): timeout"
 func wrapError(err C.qdb_error_t, operation string, keyValues ...any) error {
 	if err == 0 || err == C.qdb_e_ok_created {
 		return nil
 	}
 
+	// Panic on odd kv args - prevents subtle bugs from missing values
+	if len(keyValues)%2 != 0 {
+		panic(fmt.Sprintf("wrapError: odd number of key-value arguments provided (%d). Keys and values must be provided in pairs.", len(keyValues)))
+	}
+
 	baseErr := ErrorType(err)
-	var contextParts []string
 
-	if operation != "" {
-		contextParts = append(contextParts, fmt.Sprintf("operation=%s", operation))
-	}
+	// Pre-allocate builder capacity to avoid reallocation
+	// because error formatting is on hot path for failures
+	var sb strings.Builder
+	sb.Grow(len(operation) + len(keyValues)*20 + 10)
 
-	// Process key-value pairs
-	for i := 0; i < len(keyValues); i += 2 {
-		if i+1 < len(keyValues) {
-			key := fmt.Sprintf("%v", keyValues[i])
-			value := fmt.Sprintf("%v", keyValues[i+1])
-			contextParts = append(contextParts, fmt.Sprintf("%s=%s", key, value))
+	sb.WriteString(operation)
+
+	if len(keyValues) > 0 {
+		sb.WriteString(" (operation=")
+		sb.WriteString(operation)
+
+		// Format context pairs - allows debugging failures with full context
+		for i := 0; i < len(keyValues); i += 2 {
+			sb.WriteString(", ")
+			sb.WriteString(fmt.Sprintf("%v", keyValues[i]))
+			sb.WriteString("=")
+			sb.WriteString(fmt.Sprintf("%v", keyValues[i+1]))
 		}
+
+		sb.WriteString(")")
 	}
 
-	if len(contextParts) > 0 {
-		context := strings.Join(contextParts, ", ")
-		return fmt.Errorf("%s (%s): %w", operation, context, baseErr)
+	sb.WriteString(": ")
+
+	return fmt.Errorf("%s%w", sb.String(), baseErr)
+}
+
+// IsRetryable checks if error is transient/retryable.
+// Args:
+//
+//	err: any error (wrapped or direct)
+//
+// Returns:
+//
+//	true: network/resource errors → retry
+//	false: logic/permission errors → fail fast
+//
+// Example:
+//
+//	if IsRetryable(err) { time.Sleep(backoff); retry() }
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
 	}
 
-	return fmt.Errorf("%s: %w", operation, baseErr)
+	// Extract ErrorType from wrapped errors - enables retry logic
+	// to work with contextual errors from wrapError()
+	var errorType ErrorType
+	if !errors.As(err, &errorType) {
+		return true // Unknown errors assumed retryable to avoid data loss
+	}
+
+	// Retry decision matrix - prevents infinite loops on permanent failures
+	// while allowing recovery from transient issues
+	switch errorType {
+	// Success - no retry needed
+	case Success, Created:
+		return false
+
+	// Logic errors - retrying won't fix bad code
+	case ErrInvalidArgument, ErrInvalidHandle, ErrInvalidIterator, ErrInvalidVersion,
+		ErrInvalidProtocol, ErrInvalidReply, ErrInvalidQuery, ErrInvalidRegex,
+		ErrInvalidCryptoKey, ErrBufferTooSmall, ErrNotImplemented, ErrIteratorEnd:
+		return false
+
+	// Schema errors - retrying won't change schema
+	case ErrIncompatibleType, ErrColumnNotFound, ErrQueryTooComplex:
+		return false
+
+	// Constraint violations - retrying won't resolve conflicts
+	case ErrAliasAlreadyExists, ErrElementAlreadyExists, ErrTagAlreadySet,
+		ErrOutOfBounds, ErrOverflow, ErrUnderflow, ErrEntryTooLarge,
+		ErrAliasTooLong, ErrUnmatchedContent, ErrReservedAlias:
+		return false
+
+	// Auth failures - retrying won't fix credentials
+	case ErrAccessDenied, ErrLoginFailed, ErrOperationNotPermitted, ErrUnknownUser:
+		return false
+
+	// Config errors - retrying won't enable features
+	case ErrOperationDisabled:
+		return false
+
+	// State errors - retrying won't create missing data
+	case ErrContainerEmpty, ErrContainerFull, ErrElementNotFound, ErrTagNotSet,
+		ErrAliasNotFound, ErrHostNotFound:
+		return false
+
+	// Data integrity - retrying won't fix corruption
+	case ErrDataCorruption:
+		return false
+
+	// Resource exhaustion - retrying won't free disk space
+	case ErrNoSpaceLeft, ErrQuotaExceeded:
+		return false
+
+	// Transient errors - retry may succeed after condition clears
+	case ErrUninitialized, ErrSkipped, ErrTimeout, ErrConnectionRefused, ErrConnectionReset,
+		ErrUnstableCluster, ErrTryAgain, ErrConflict, ErrNotConnected, ErrResourceLocked,
+		ErrSystemRemote, ErrSystemLocal, ErrInternalRemote, ErrInternalLocal,
+		ErrNoMemoryRemote, ErrNoMemoryLocal, ErrTransactionPartialFailure, ErrClockSkew,
+		ErrInterrupted, ErrNetworkInbufTooSmall, ErrNetworkError, ErrPartialFailure,
+		ErrAsyncPipeFull:
+		return true
+
+	// Unknown errors assumed retryable - prevents data loss from new errors
+	default:
+		return true
+	}
 }

--- a/error.go
+++ b/error.go
@@ -280,15 +280,6 @@ func IsRetryable(err error) bool {
 	case ErrNoSpaceLeft, ErrQuotaExceeded:
 		return false
 
-	// Transient errors - retry may succeed after condition clears
-	case ErrUninitialized, ErrSkipped, ErrTimeout, ErrConnectionRefused, ErrConnectionReset,
-		ErrUnstableCluster, ErrTryAgain, ErrConflict, ErrNotConnected, ErrResourceLocked,
-		ErrSystemRemote, ErrSystemLocal, ErrInternalRemote, ErrInternalLocal,
-		ErrNoMemoryRemote, ErrNoMemoryLocal, ErrTransactionPartialFailure, ErrClockSkew,
-		ErrInterrupted, ErrNetworkInbufTooSmall, ErrNetworkError, ErrPartialFailure,
-		ErrAsyncPipeFull:
-		return true
-
 	// Unknown errors assumed retryable - prevents data loss from new errors
 	default:
 		return true

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,269 @@
+package qdb
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ------------------------------------------------------------------
+// Is() method tests
+// ------------------------------------------------------------------
+
+func TestErrorType_Is_SameErrorType(t *testing.T) {
+	err1 := ErrAliasNotFound
+	err2 := ErrAliasNotFound
+	
+	assert.True(t, err1.Is(err2))
+	assert.True(t, err2.Is(err1))
+}
+
+func TestErrorType_Is_DifferentErrorTypes(t *testing.T) {
+	err1 := ErrAliasNotFound
+	err2 := ErrAliasAlreadyExists
+	
+	assert.False(t, err1.Is(err2))
+	assert.False(t, err2.Is(err1))
+}
+
+func TestErrorType_Is_NonErrorType(t *testing.T) {
+	err1 := ErrAliasNotFound
+	err2 := errors.New("standard error")
+	
+	assert.False(t, err1.Is(err2))
+}
+
+func TestErrorType_Is_WithStandardLibraryErrorsIs(t *testing.T) {
+	err1 := ErrAliasNotFound
+	err2 := ErrAliasNotFound
+	err3 := ErrAliasAlreadyExists
+	
+	assert.True(t, errors.Is(err1, err2))
+	assert.False(t, errors.Is(err1, err3))
+}
+
+func TestErrorType_Is_WithWrappedError(t *testing.T) {
+	baseErr := ErrAliasNotFound
+	wrappedErr := fmt.Errorf("operation failed: %w", baseErr)
+	
+	assert.True(t, errors.Is(wrappedErr, baseErr))
+	assert.True(t, errors.Is(wrappedErr, ErrAliasNotFound))
+}
+
+func TestErrorType_Is_MultipleTypes(t *testing.T) {
+	testCases := []struct {
+		name   string
+		err1   ErrorType
+		err2   ErrorType
+		same   bool
+	}{
+		{"same alias not found", ErrAliasNotFound, ErrAliasNotFound, true},
+		{"same alias already exists", ErrAliasAlreadyExists, ErrAliasAlreadyExists, true},
+		{"same timeout", ErrTimeout, ErrTimeout, true},
+		{"same connection refused", ErrConnectionRefused, ErrConnectionRefused, true},
+		{"different errors", ErrAliasNotFound, ErrAliasAlreadyExists, false},
+		{"different timeout vs not found", ErrTimeout, ErrAliasNotFound, false},
+		{"different connection vs timeout", ErrConnectionRefused, ErrTimeout, false},
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := tc.err1.Is(tc.err2)
+			assert.Equal(t, tc.same, result)
+		})
+	}
+}
+
+func TestErrorsPackage_Integration_WithErrorType(t *testing.T) {
+	baseErr := ErrTimeout
+	
+	// Test fmt.Errorf with %w
+	wrappedErr := fmt.Errorf("operation failed: %w", baseErr)
+	
+	// Test errors.Is
+	assert.True(t, errors.Is(wrappedErr, ErrTimeout))
+	assert.False(t, errors.Is(wrappedErr, ErrAliasNotFound))
+	
+	// Test errors.As
+	var target ErrorType
+	assert.True(t, errors.As(wrappedErr, &target))
+	assert.Equal(t, ErrTimeout, target)
+	
+	// Test errors.Unwrap
+	unwrapped := errors.Unwrap(wrappedErr)
+	assert.Equal(t, ErrTimeout, unwrapped)
+}
+
+func TestErrorsPackage_ChainedWrapping(t *testing.T) {
+	// Create a wrapped error
+	baseErr := ErrTimeout
+	wrappedErr := fmt.Errorf("database query failed: %w", baseErr)
+	
+	// Wrap it again
+	chainedErr := fmt.Errorf("database operation failed: %w", wrappedErr)
+	
+	// Test that errors.Is still works through the chain
+	assert.True(t, errors.Is(chainedErr, ErrTimeout))
+	assert.False(t, errors.Is(chainedErr, ErrAliasNotFound))
+}
+
+func TestErrorType_TypeAssertions(t *testing.T) {
+	var err error = ErrAliasNotFound
+	
+	// Test type assertion
+	errType, ok := err.(ErrorType)
+	assert.True(t, ok)
+	assert.Equal(t, ErrAliasNotFound, errType)
+	
+	// Test with errors.As
+	var target ErrorType
+	assert.True(t, errors.As(err, &target))
+	assert.Equal(t, ErrAliasNotFound, target)
+}
+
+func TestErrorType_InterfaceCompatibility(t *testing.T) {
+	// Test that ErrorType implements error interface
+	var err error = ErrAliasNotFound
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "An entry matching the provided alias cannot be found.")
+}
+
+func TestErrorType_WrappingScenarios(t *testing.T) {
+	// Test scenarios that demonstrate the new Is() method works with wrapped errors
+	// This simulates what wrapError would produce
+	
+	baseErr := ErrAliasNotFound
+	
+	// Test simple wrapping
+	wrappedErr := fmt.Errorf("get operation failed: %w", baseErr)
+	assert.True(t, errors.Is(wrappedErr, ErrAliasNotFound))
+	
+	// Test with context-like wrapping
+	contextErr := fmt.Errorf("connect (operation=connect, uri=localhost:2836): %w", baseErr)
+	assert.True(t, errors.Is(contextErr, ErrAliasNotFound))
+	
+	// Test chained wrapping
+	chainedErr := fmt.Errorf("database operation failed: %w", wrappedErr)
+	assert.True(t, errors.Is(chainedErr, ErrAliasNotFound))
+}
+
+func TestErrorType_BackwardCompatibility(t *testing.T) {
+	// Test that the existing error behavior is preserved
+	// This simulates what makeErrorOrNil would return
+	
+	aliasNotFoundErr := ErrAliasNotFound
+	
+	// Test that the error still works as before
+	assert.Error(t, aliasNotFoundErr)
+	assert.Contains(t, aliasNotFoundErr.Error(), "An entry matching the provided alias cannot be found.")
+	
+	// Test that the new Is() method works
+	assert.True(t, errors.Is(aliasNotFoundErr, ErrAliasNotFound))
+	assert.False(t, errors.Is(aliasNotFoundErr, ErrAliasAlreadyExists))
+}
+
+// ------------------------------------------------------------------
+// Additional comprehensive tests for error handling patterns
+// ------------------------------------------------------------------
+
+func TestErrorType_Is_AllKeyErrorTypes(t *testing.T) {
+	// Test key error types that are commonly used
+	keyErrors := []struct {
+		name string
+		err  ErrorType
+	}{
+		{"alias not found", ErrAliasNotFound},
+		{"alias already exists", ErrAliasAlreadyExists},
+		{"timeout", ErrTimeout},
+		{"connection refused", ErrConnectionRefused},
+		{"invalid argument", ErrInvalidArgument},
+		{"access denied", ErrAccessDenied},
+		{"not connected", ErrNotConnected},
+		{"invalid query", ErrInvalidQuery},
+	}
+	
+	for _, keyErr := range keyErrors {
+		t.Run(keyErr.name+"_self_comparison", func(t *testing.T) {
+			assert.True(t, keyErr.err.Is(keyErr.err))
+		})
+		
+		t.Run(keyErr.name+"_with_errors_Is", func(t *testing.T) {
+			assert.True(t, errors.Is(keyErr.err, keyErr.err))
+		})
+		
+		t.Run(keyErr.name+"_wrapped_scenario", func(t *testing.T) {
+			// Test wrapping scenarios similar to what wrapError would create
+			wrappedErr := fmt.Errorf("operation failed: %w", keyErr.err)
+			assert.True(t, errors.Is(wrappedErr, keyErr.err))
+			
+			// Test with context-like wrapping
+			contextErr := fmt.Errorf("operation (key=value, timeout=5s): %w", keyErr.err)
+			assert.True(t, errors.Is(contextErr, keyErr.err))
+		})
+	}
+}
+
+func TestErrorType_Is_NegativeTests(t *testing.T) {
+	// Test that different errors are not equal to each other
+	testPairs := []struct {
+		name string
+		err1 ErrorType
+		err2 ErrorType
+	}{
+		{"alias not found vs alias exists", ErrAliasNotFound, ErrAliasAlreadyExists},
+		{"timeout vs connection refused", ErrTimeout, ErrConnectionRefused},
+		{"invalid argument vs access denied", ErrInvalidArgument, ErrAccessDenied},
+		{"not connected vs invalid query", ErrNotConnected, ErrInvalidQuery},
+	}
+	
+	for _, pair := range testPairs {
+		t.Run(pair.name, func(t *testing.T) {
+			assert.False(t, pair.err1.Is(pair.err2))
+			assert.False(t, pair.err2.Is(pair.err1))
+			assert.False(t, errors.Is(pair.err1, pair.err2))
+			assert.False(t, errors.Is(pair.err2, pair.err1))
+		})
+	}
+}
+
+func TestErrorType_DeepWrappingScenarios(t *testing.T) {
+	// Test deep wrapping scenarios that would occur with wrapError usage
+	baseErr := ErrTimeout
+	
+	// Level 1: Basic wrapping (simulating wrapError)
+	level1 := fmt.Errorf("query (table=stocks, timeout=30s): %w", baseErr)
+	assert.True(t, errors.Is(level1, ErrTimeout))
+	
+	// Level 2: Service layer wrapping
+	level2 := fmt.Errorf("database service failed: %w", level1)
+	assert.True(t, errors.Is(level2, ErrTimeout))
+	
+	// Level 3: Application layer wrapping
+	level3 := fmt.Errorf("API request failed: %w", level2)
+	assert.True(t, errors.Is(level3, ErrTimeout))
+	
+	// Test errors.As works through deep wrapping
+	var target ErrorType
+	assert.True(t, errors.As(level3, &target))
+	assert.Equal(t, ErrTimeout, target)
+}
+
+func TestErrorType_ErrorAsWithDifferentTypes(t *testing.T) {
+	// Test errors.As with different error types
+	baseErr := ErrAliasNotFound
+	wrappedErr := fmt.Errorf("operation failed: %w", baseErr)
+	
+	// Test successful As
+	var target ErrorType
+	assert.True(t, errors.As(wrappedErr, &target))
+	assert.Equal(t, ErrAliasNotFound, target)
+	
+	// Test As with wrong type
+	var wrongTarget *ErrorType
+	assert.False(t, errors.As(wrappedErr, &wrongTarget))
+	
+	// Test As with interface - remove this as errors.As doesn't work with *error
+	// The ErrorType test above already validates the As functionality
+}

--- a/examples/tutorial/main.go
+++ b/examples/tutorial/main.go
@@ -12,7 +12,6 @@ import (
 // import-end
 
 func main() {
-
 	handle, err := connect()
 	if err != nil {
 		fmt.Printf("Failed to connect to QuasarDB: %s", err.Error())
@@ -70,7 +69,6 @@ func connect() (*qdb.HandleType, error) {
 	timeoutDuration := time.Duration(120) * time.Second
 	handle, err := qdb.SetupHandle(clusterURI, timeoutDuration)
 	// connect-end
-
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +90,6 @@ func secureConnect() (*qdb.HandleType, error) {
 		qdb.EncryptNone,
 	)
 	// secure-connect-end
-
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +274,7 @@ func columnRead(handle *qdb.HandleType) error {
 func query(handle *qdb.HandleType) error {
 	// query-start
 
-	query := handle.Query(fmt.Sprintf("SELECT SUM(volume) FROM stocks"))
+	query := handle.Query("SELECT SUM(volume) FROM stocks")
 	table, err := query.Execute()
 	if err != nil {
 		return err

--- a/examples/tutorial/main.go
+++ b/examples/tutorial/main.go
@@ -257,7 +257,7 @@ func columnRead(handle *qdb.HandleType) error {
 		return err
 	}
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		timestamp := openResults[i].Timestamp()
 		open := openResults[i].Content()
 		close := closeResults[i].Content()

--- a/find.go
+++ b/find.go
@@ -5,6 +5,7 @@ package qdb
 	#include <stdlib.h>
 */
 import "C"
+
 import (
 	"bytes"
 	"errors"

--- a/find.go
+++ b/find.go
@@ -97,5 +97,5 @@ func (q Find) ExecuteString(query string) ([]string, error) {
 		}
 		return output, nil
 	}
-	return nil, ErrorType(err)
+	return nil, wrapError(err, "find_execute", "query", query)
 }

--- a/find_test.go
+++ b/find_test.go
@@ -1,8 +1,8 @@
 package qdb
 
 import (
-	"testing"
 	"fmt"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/handle.go
+++ b/handle.go
@@ -106,7 +106,7 @@ func (h HandleType) APIBuild() string {
 //	}
 func (h HandleType) Open(protocol Protocol) error {
 	err := C.qdb_open(&h.handle, C.qdb_protocol_t(protocol))
-	return makeErrorOrNil(err)
+	return wrapError(err, "handle_open", "protocol", protocol)
 }
 
 // SetTimeout sets the timeout for all network operations.
@@ -129,7 +129,7 @@ func (h HandleType) Open(protocol Protocol) error {
 //	}
 func (h HandleType) SetTimeout(timeout time.Duration) error {
 	err := C.qdb_option_set_timeout(h.handle, C.int(timeout/time.Millisecond))
-	return makeErrorOrNil(err)
+	return wrapError(err, "handle_set_timeout", "timeout_ms", timeout/time.Millisecond)
 }
 
 // Encryption is an encryption option.
@@ -164,7 +164,7 @@ const (
 //	}
 func (h HandleType) SetEncryption(encryption Encryption) error {
 	err := C.qdb_option_set_encryption(h.handle, C.qdb_encryption_t(encryption))
-	return makeErrorOrNil(err)
+	return wrapError(err, "set_encryption", "type", encryption)
 }
 
 // jSONCredentialConfig holds username and secret key from JSON credential files.
@@ -252,7 +252,7 @@ func (h HandleType) AddUserCredentials(name, secret string) error {
 	userSecret := convertToCharStar(secret)
 	defer releaseCharStar(userSecret)
 	qdbErr := C.qdb_option_set_user_credentials(h.handle, username, userSecret)
-	return makeErrorOrNil(qdbErr)
+	return wrapError(qdbErr, "add_user_credentials")
 }
 
 // AddClusterPublicKey adds the cluster public key for secure communication.
@@ -277,7 +277,7 @@ func (h HandleType) AddClusterPublicKey(secret string) error {
 	clusterPublicKey := convertToCharStar(secret)
 	defer releaseCharStar(clusterPublicKey)
 	qdbErr := C.qdb_option_set_cluster_public_key(h.handle, clusterPublicKey)
-	return makeErrorOrNil(qdbErr)
+	return wrapError(qdbErr, "add_cluster_public_key")
 }
 
 // SetMaxCardinality sets the maximum allowed cardinality for queries.
@@ -300,7 +300,7 @@ func (h HandleType) AddClusterPublicKey(secret string) error {
 //	}
 func (h HandleType) SetMaxCardinality(maxCardinality uint) error {
 	err := C.qdb_option_set_max_cardinality(h.handle, C.qdb_uint_t(maxCardinality))
-	return makeErrorOrNil(err)
+	return wrapError(err, "handle_set_max_cardinality", "max_cardinality", maxCardinality)
 }
 
 // SetCompression sets the compression level for outgoing messages.
@@ -369,7 +369,7 @@ func (h HandleType) SetClientMaxInBufSize(bufSize uint) error {
 func (h HandleType) GetClientMaxInBufSize() (uint, error) {
 	var bufSize C.size_t
 	err := C.qdb_option_get_client_max_in_buf_size(h.handle, &bufSize)
-	return uint(bufSize), makeErrorOrNil(err)
+	return uint(bufSize), wrapError(err, "get_client_max_in_buf_size")
 }
 
 // GetClusterMaxInBufSize gets the maximum incoming buffer size allowed by the cluster.
@@ -392,7 +392,7 @@ func (h HandleType) GetClientMaxInBufSize() (uint, error) {
 func (h HandleType) GetClusterMaxInBufSize() (uint, error) {
 	var bufSize C.size_t
 	err := C.qdb_option_get_cluster_max_in_buf_size(h.handle, &bufSize)
-	return uint(bufSize), makeErrorOrNil(err)
+	return uint(bufSize), wrapError(err, "get_cluster_max_in_buf_size")
 }
 
 // GetClientMaxParallelism gets the maximum parallelism option of the client.
@@ -466,7 +466,7 @@ func (h HandleType) Connect(clusterURI string) error {
 	if err == C.qdb_e_ok {
 		L().Info("successfully connected", "cluster", clusterURI)
 	}
-	return makeErrorOrNil(err)
+	return wrapError(err, "connect", "uri", clusterURI)
 }
 
 // Close closes the handle and releases all resources.
@@ -592,7 +592,7 @@ func (h HandleType) GetTagged(tag string) ([]string, error) {
 		}
 		return output, nil
 	}
-	return nil, ErrorType(err)
+	return nil, wrapError(err, "get_tagged", "tag", tag)
 }
 
 // PrefixGet retrieves all entries matching the provided prefix.
@@ -1152,7 +1152,7 @@ func (h HandleType) TsBatch(cols ...TsBatchColumnInfo) (*TsBatch, error) {
 	batch := &TsBatch{}
 	batch.h = h
 	err := C.qdb_ts_batch_table_init(h.handle, columns, columnsCount, &batch.table)
-	return batch, makeErrorOrNil(err)
+	return batch, wrapError(err, "ts_batch_init", "columns", len(cols))
 }
 
 // GetLastError retrieves last operation error.

--- a/handle_options.go
+++ b/handle_options.go
@@ -85,6 +85,7 @@ func (o *HandleOptions) WithClusterUri(uri string) *HandleOptions {
 	// Create a copy to maintain immutability
 	opts := *o
 	opts.clusterURI = uri
+
 	return &opts
 }
 
@@ -93,6 +94,7 @@ func (o *HandleOptions) WithClusterPublicKeyFile(path string) *HandleOptions {
 	// Create a copy to maintain immutability
 	opts := *o
 	opts.clusterPublicKeyFile = path
+
 	return &opts
 }
 
@@ -101,6 +103,7 @@ func (o *HandleOptions) WithClusterPublicKey(key string) *HandleOptions {
 	// Create a copy to maintain immutability
 	opts := *o
 	opts.clusterPublicKey = key
+
 	return &opts
 }
 
@@ -109,6 +112,7 @@ func (o *HandleOptions) WithUserSecurityFile(path string) *HandleOptions {
 	// Create a copy to maintain immutability
 	opts := *o
 	opts.userSecurityFile = path
+
 	return &opts
 }
 
@@ -117,6 +121,7 @@ func (o *HandleOptions) WithUserName(name string) *HandleOptions {
 	// Create a copy to maintain immutability
 	opts := *o
 	opts.userName = name
+
 	return &opts
 }
 
@@ -125,6 +130,7 @@ func (o *HandleOptions) WithUserSecret(secret string) *HandleOptions {
 	// Create a copy to maintain immutability
 	opts := *o
 	opts.userSecret = secret
+
 	return &opts
 }
 
@@ -133,6 +139,7 @@ func (o *HandleOptions) WithEncryption(encryption Encryption) *HandleOptions {
 	// Create a copy to maintain immutability
 	opts := *o
 	opts.encryption = encryption
+
 	return &opts
 }
 
@@ -141,6 +148,7 @@ func (o *HandleOptions) WithCompression(compression Compression) *HandleOptions 
 	// Create a copy to maintain immutability
 	opts := *o
 	opts.compression = compression
+
 	return &opts
 }
 
@@ -149,6 +157,7 @@ func (o *HandleOptions) WithClientMaxParallelism(n int) *HandleOptions {
 	// Create a copy to maintain immutability
 	opts := *o
 	opts.clientMaxParallelism = n
+
 	return &opts
 }
 
@@ -157,6 +166,7 @@ func (o *HandleOptions) WithClientMaxInBufSize(size uint) *HandleOptions {
 	// Create a copy to maintain immutability
 	opts := *o
 	opts.clientMaxInBufSize = size
+
 	return &opts
 }
 
@@ -165,6 +175,7 @@ func (o *HandleOptions) WithTimeout(timeout time.Duration) *HandleOptions {
 	// Create a copy to maintain immutability
 	opts := *o
 	opts.timeout = timeout
+
 	return &opts
 }
 

--- a/handle_test.go
+++ b/handle_test.go
@@ -1,6 +1,7 @@
 package qdb
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -115,7 +116,7 @@ func TestHandleGetLastErrorAfterFailedConnect(t *testing.T) {
 	err = h.Connect("")
 	msg, last := h.GetLastError()
 
-	assert.Equal(t, err, last)
+	assert.True(t, errors.Is(err, last), "Connect error should contain GetLastError")
 	assert.Equal(t, "at qdb_connect: Got NULL uri", msg)
 }
 

--- a/logger.go
+++ b/logger.go
@@ -207,7 +207,7 @@ func init() {
 }
 
 // L returns the current package-level logger.
-func L() Logger { 
+func L() Logger {
 	return globalLogger.Load().(*loggerHolder).logger
 }
 

--- a/logger.go
+++ b/logger.go
@@ -83,10 +83,11 @@ func splitTimestamp(args []any) (ts time.Time, rest []any) {
 	// the *value* during the next iteration; `skip` flags that intent.
 	skip := false
 
-	for i := range len(args) {
+	for i := range args {
 		// Honour skip request coming from the previous iteration.
 		if skip {
 			skip = false
+
 			continue
 		}
 
@@ -114,6 +115,7 @@ func splitTimestamp(args []any) (ts time.Time, rest []any) {
 					ts = t
 					// Skip the value on the next loop iteration.
 					skip = true
+
 					continue
 				}
 			}
@@ -135,6 +137,7 @@ func (s *slogAdapter) log(level slog.Level, msg string, args ...any) {
 	// Fast path: no custom timestamp requested.
 	if ts.IsZero() {
 		s.l.Log(context.Background(), level, msg, rest...)
+
 		return
 	}
 
@@ -193,6 +196,7 @@ func defaultLogger() Logger {
 	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
 		Level: slog.LevelInfo, // default level; tweak in tests if needed
 	})
+
 	return &slogAdapter{l: slog.New(handler)}
 }
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -280,7 +280,7 @@ func TestLoggerConcurrency(t *testing.T) {
 
 	// Run concurrent operations
 	done := make(chan bool)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		go func(id int) {
 			defer func() { done <- true }()
 
@@ -298,7 +298,7 @@ func TestLoggerConcurrency(t *testing.T) {
 	}
 
 	// Wait for all goroutines
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		<-done
 	}
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -18,7 +18,7 @@ func testLogFunction() {
 	L().Error("test error message", "key4", "value4")
 	L().Panic("test panic message", "key5", "value5")
 	L().Detailed("test detailed message", "key6", "value6")
-	
+
 	// Test With() functionality
 	logger := L().With("request_id", "12345")
 	logger.Info("test with context", "user", "test-user")
@@ -27,40 +27,40 @@ func testLogFunction() {
 // captureStderr captures stderr output during function execution.
 func captureStderr(t *testing.T, f func()) string {
 	t.Helper()
-	
+
 	// Save original stderr
 	origStderr := os.Stderr
-	
+
 	// Create pipe for capturing
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("failed to create pipe: %v", err)
 	}
-	
+
 	// Channel to signal reading is done
 	done := make(chan string)
-	
+
 	// Start reading in a goroutine
 	go func() {
 		var buf bytes.Buffer
 		io.Copy(&buf, r)
 		done <- buf.String()
 	}()
-	
+
 	// Replace stderr
 	os.Stderr = w
-	
+
 	// Run the function
 	f()
-	
+
 	// Restore stderr and close write end
 	os.Stderr = origStderr
 	w.Close()
-	
+
 	// Wait for reading to complete
 	output := <-done
 	r.Close()
-	
+
 	return output
 }
 
@@ -72,28 +72,28 @@ func TestDefaultLoggerOutput(t *testing.T) {
 		// Always restore original logger
 		SetLogger(originalLogger)
 	}()
-	
+
 	// Create a buffer to capture output
 	var buf bytes.Buffer
 	handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{
 		Level: slog.LevelDebug, // Enable all log levels
 	})
-	
+
 	// Create logger with buffer handler
 	logger := NewSlogAdapter(handler)
 	SetLogger(logger)
-	
+
 	// Call test function
 	testLogFunction()
-	
+
 	// Get output from buffer
 	output := buf.String()
-	
+
 	// Verify we got output
 	if output == "" {
 		t.Error("expected log output, got empty string")
 	}
-	
+
 	// Check for expected messages
 	expectedMessages := []string{
 		"test debug message",
@@ -104,13 +104,13 @@ func TestDefaultLoggerOutput(t *testing.T) {
 		"test detailed message",
 		"test with context",
 	}
-	
+
 	for _, msg := range expectedMessages {
 		if !strings.Contains(output, msg) {
 			t.Errorf("expected output to contain %q, got:\n%s", msg, output)
 		}
 	}
-	
+
 	// Check for attributes
 	expectedAttrs := []string{
 		"key1=value1",
@@ -122,7 +122,7 @@ func TestDefaultLoggerOutput(t *testing.T) {
 		"request_id=12345",
 		"user=test-user",
 	}
-	
+
 	for _, attr := range expectedAttrs {
 		if !strings.Contains(output, attr) {
 			t.Errorf("expected output to contain attribute %q, got:\n%s", attr, output)
@@ -138,13 +138,13 @@ func TestNilLoggerNoOutput(t *testing.T) {
 		// Always restore original logger
 		SetLogger(originalLogger)
 	}()
-	
+
 	// Set NilLogger
 	SetLogger(&NilLogger{})
-	
+
 	// Capture output
 	output := captureStderr(t, testLogFunction)
-	
+
 	// Verify no output
 	if output != "" {
 		t.Errorf("expected no output from NilLogger, got:\n%s", output)
@@ -155,23 +155,23 @@ func TestNilLoggerNoOutput(t *testing.T) {
 func TestLoggerIsolation(t *testing.T) {
 	// Save current logger
 	originalLogger := L()
-	
+
 	// Run test that changes logger
 	t.Run("ModifyLogger", func(t *testing.T) {
 		defer func() {
 			// Restore logger even if test panics
 			SetLogger(originalLogger)
 		}()
-		
+
 		// Change to NilLogger
 		SetLogger(&NilLogger{})
-		
+
 		// Verify it's set
 		if _, ok := L().(*NilLogger); !ok {
 			t.Error("expected NilLogger to be set")
 		}
 	})
-	
+
 	// Verify logger is restored
 	if L() != originalLogger {
 		t.Error("logger was not properly restored after test")
@@ -182,46 +182,46 @@ func TestLoggerIsolation(t *testing.T) {
 func TestDefaultLoggerFunction(t *testing.T) {
 	// Get a default logger
 	logger := defaultLogger()
-	
+
 	// Verify it's not nil
 	if logger == nil {
 		t.Fatal("defaultLogger() returned nil")
 	}
-	
+
 	// Test that it produces output
 	originalLogger := L()
 	defer SetLogger(originalLogger)
-	
+
 	// Create a pipe before creating the logger
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatalf("failed to create pipe: %v", err)
 	}
-	
+
 	// Save original stderr
 	origStderr := os.Stderr
 	os.Stderr = w
-	
+
 	// Create a new default logger that will use the piped stderr
 	handler := slog.NewTextHandler(w, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	})
 	testLogger := NewSlogAdapter(handler)
 	SetLogger(testLogger)
-	
+
 	// Log the message
 	L().Info("default logger test")
-	
+
 	// Restore stderr and close write end
 	os.Stderr = origStderr
 	w.Close()
-	
+
 	// Read output
 	var buf bytes.Buffer
 	io.Copy(&buf, r)
 	r.Close()
 	output := buf.String()
-	
+
 	if !strings.Contains(output, "default logger test") {
 		t.Errorf("expected output from default logger, got:\n%s", output)
 	}
@@ -230,25 +230,25 @@ func TestDefaultLoggerFunction(t *testing.T) {
 // TestNilLoggerWith verifies that NilLogger.With() returns a NilLogger.
 func TestNilLoggerWith(t *testing.T) {
 	nilLogger := &NilLogger{}
-	
+
 	// Call With() with some attributes
 	newLogger := nilLogger.With("key", "value", "another", 123)
-	
+
 	// Verify it returns a NilLogger
 	if _, ok := newLogger.(*NilLogger); !ok {
 		t.Errorf("expected NilLogger.With() to return *NilLogger, got %T", newLogger)
 	}
-	
+
 	// Verify the new logger also produces no output
 	originalLogger := L()
 	defer SetLogger(originalLogger)
-	
+
 	SetLogger(newLogger)
-	
+
 	output := captureStderr(t, func() {
 		L().Info("should not appear")
 	})
-	
+
 	if output != "" {
 		t.Errorf("expected no output from NilLogger.With(), got:\n%s", output)
 	}
@@ -265,7 +265,7 @@ func TestSetLoggerPanicOnNil(t *testing.T) {
 			}
 		}
 	}()
-	
+
 	SetLogger(nil)
 }
 
@@ -274,33 +274,33 @@ func TestLoggerConcurrency(t *testing.T) {
 	// Save current logger
 	originalLogger := L()
 	defer SetLogger(originalLogger)
-	
+
 	// Set to NilLogger for silent operation
 	SetLogger(&NilLogger{})
-	
+
 	// Run concurrent operations
 	done := make(chan bool)
 	for i := 0; i < 10; i++ {
 		go func(id int) {
 			defer func() { done <- true }()
-			
+
 			// Perform various logger operations
 			L().Debug("concurrent", "goroutine", id)
 			L().Info("concurrent", "goroutine", id)
 			logger := L().With("id", id)
 			logger.Warn("concurrent with context")
-			
+
 			// Occasionally change logger
 			if id%3 == 0 {
 				SetLogger(&NilLogger{})
 			}
 		}(i)
 	}
-	
+
 	// Wait for all goroutines
 	for i := 0; i < 10; i++ {
 		<-done
 	}
-	
+
 	// If we get here without deadlock or panic, concurrency is working
 }

--- a/node.go
+++ b/node.go
@@ -5,6 +5,7 @@ package qdb
 	#include <stdlib.h>
 */
 import "C"
+
 import (
 	"encoding/json"
 	"unsafe"
@@ -17,6 +18,7 @@ type Node struct {
 }
 
 // Status :
+//
 //	Returns the status of a node.
 //
 //	The status is a JSON object and contains current information of the node state, as described in the documentation.
@@ -32,6 +34,7 @@ func (n Node) Status() (NodeStatus, error) {
 }
 
 // RawStatus :
+//
 //	Returns the status of a node.
 //
 //	The status is a JSON object as a byte array and contains current information of the node state, as described in the documentation.
@@ -50,6 +53,7 @@ func (n Node) RawStatus() ([]byte, error) {
 }
 
 // Config :
+//
 //	Returns the configuration as a byte array of a json object, you can use a method of your choice to unmarshall it.
 //	An example is available using the gabs library
 //
@@ -59,6 +63,7 @@ func (n Node) Config() ([]byte, error) {
 }
 
 // RawConfig :
+//
 //	Returns the configuration of a node.
 //
 //	The configuration is a JSON object as a byte array, as described in the documentation.
@@ -77,6 +82,7 @@ func (n Node) RawConfig() ([]byte, error) {
 }
 
 // Topology :
+//
 //	Returns the topology of a node.
 //
 //	The topology is a JSON object containing the node address, and the addresses of its successor and predecessor.
@@ -91,6 +97,7 @@ func (n Node) Topology() (NodeTopology, error) {
 }
 
 // RawTopology :
+//
 //	Returns the topology of a node.
 //
 //	The topology is a JSON object as a byte array containing the node address, and the addresses of its successor and predecessor.

--- a/node.go
+++ b/node.go
@@ -49,7 +49,7 @@ func (n Node) RawStatus() ([]byte, error) {
 		output = C.GoBytes(unsafe.Pointer(content), C.int(contentLength))
 		n.Release(unsafe.Pointer(content))
 	}
-	return output, makeErrorOrNil(err)
+	return output, wrapError(err, "node_raw_status", "uri", n.uri)
 }
 
 // Config :
@@ -78,7 +78,7 @@ func (n Node) RawConfig() ([]byte, error) {
 		output = C.GoBytes(unsafe.Pointer(content), C.int(contentLength))
 		n.Release(unsafe.Pointer(content))
 	}
-	return output, makeErrorOrNil(err)
+	return output, wrapError(err, "node_config", "uri", n.uri)
 }
 
 // Topology :
@@ -112,5 +112,5 @@ func (n Node) RawTopology() ([]byte, error) {
 		output = C.GoBytes(unsafe.Pointer(content), C.int(contentLength))
 		n.Release(unsafe.Pointer(content))
 	}
-	return output, makeErrorOrNil(err)
+	return output, wrapError(err, "node_topology", "uri", n.uri)
 }

--- a/qdb_log_cgo.go
+++ b/qdb_log_cgo.go
@@ -6,6 +6,7 @@ package qdb
 	void go_callback_log(qdb_log_level_t log_level, unsigned long * date, unsigned long pid, unsigned long tid, char * message_buffer, size_t message_size);
 */
 import "C"
+
 import (
 	"log/slog"
 	"math"

--- a/query.go
+++ b/query.go
@@ -37,6 +37,7 @@ package qdb
 	}
 */
 import "C"
+
 import (
 	"math"
 	"time"

--- a/query.go
+++ b/query.go
@@ -123,7 +123,7 @@ func (r *QueryPoint) GetDouble() (float64, error) {
 	if result._type == C.qdb_query_result_double {
 		return float64(C.get_double_from_payload(result)), nil
 	}
-	return 0, makeErrorOrNil(C.qdb_e_operation_not_permitted)
+	return 0, wrapError(C.qdb_e_operation_not_permitted, "query_point_get_double", "wrong_type", "expected_double")
 }
 
 // GetBlob : retrieve a double from the interface
@@ -132,7 +132,7 @@ func (r *QueryPoint) GetBlob() ([]byte, error) {
 		result := (*C.qdb_point_result_t)(unsafe.Pointer(r))
 		return getBlobUnsafe(result), nil
 	}
-	return []byte{}, makeErrorOrNil(C.qdb_e_operation_not_permitted)
+	return []byte{}, wrapError(C.qdb_e_operation_not_permitted, "query_point_get_blob", "wrong_type", "expected_blob")
 }
 
 // GetInt64 : retrieve an int64 from the interface
@@ -141,7 +141,7 @@ func (r *QueryPoint) GetInt64() (int64, error) {
 	if result._type == C.qdb_query_result_int64 {
 		return int64(C.get_int64_from_payload(result)), nil
 	}
-	return 0, makeErrorOrNil(C.qdb_e_operation_not_permitted)
+	return 0, wrapError(C.qdb_e_operation_not_permitted, "query_point_get_int64", "wrong_type", "expected_int64")
 }
 
 // GetString : retrieve a string from the interface
@@ -150,7 +150,7 @@ func (r *QueryPoint) GetString() (string, error) {
 		result := (*C.qdb_point_result_t)(unsafe.Pointer(r))
 		return getStringUnsafe(result), nil
 	}
-	return "", makeErrorOrNil(C.qdb_e_operation_not_permitted)
+	return "", wrapError(C.qdb_e_operation_not_permitted, "query_point_get_string", "wrong_type", "expected_string")
 }
 
 // GetTimestamp : retrieve a timestamp from the interface
@@ -159,7 +159,7 @@ func (r *QueryPoint) GetTimestamp() (time.Time, error) {
 	if result._type == C.qdb_query_result_timestamp {
 		return TimespecToStructG(C.get_timestamp_from_payload(result)), nil
 	}
-	return time.Unix(-1, -1), makeErrorOrNil(C.qdb_e_operation_not_permitted)
+	return time.Unix(-1, -1), wrapError(C.qdb_e_operation_not_permitted, "query_point_get_timestamp", "wrong_type", "expected_timestamp")
 }
 
 // GetCount : retrieve the count from the interface
@@ -265,7 +265,7 @@ func (q Query) Execute() (*QueryResult, error) {
 	var r QueryResult
 	err := C.qdb_query(q.handle, query, &r.result)
 	if r.result == nil {
-		return nil, makeErrorOrNil(err)
+		return nil, wrapError(err, "query_execute", "query", q.query)
 	}
-	return &r, makeErrorOrNil(err)
+	return &r, wrapError(err, "query_execute", "query", q.query)
 }

--- a/query_test.go
+++ b/query_test.go
@@ -10,142 +10,142 @@ import (
 )
 
 const (
-    blobIndex      = 0
-    doubleIndex    = 1
-    int64Index     = 2
-    stringIndex    = 3
-    timestampIndex = 4
-    symbolIndex    = 5
+	blobIndex      = 0
+	doubleIndex    = 1
+	int64Index     = 2
+	stringIndex    = 3
+	timestampIndex = 4
+	symbolIndex    = 5
 )
 
 func TestQueryExecuteReturnsExpectedResults(t *testing.T) {
-    handle := newTestHandle(t)
-    defer handle.Close()
+	handle := newTestHandle(t)
+	defer handle.Close()
 
-    td := newTestTimeseriesAllColumns(t, handle, 8)
+	td := newTestTimeseriesAllColumns(t, handle, 8)
 
-    query := fmt.Sprintf("select * from %s in range(1970, +10d)", td.Alias)
-    result, err := handle.Query(query).Execute()
-    require.NoError(t, err)
-    require.NotNil(t, result)
-    defer handle.Release(unsafe.Pointer(result))
+	query := fmt.Sprintf("select * from %s in range(1970, +10d)", td.Alias)
+	result, err := handle.Query(query).Execute()
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	defer handle.Release(unsafe.Pointer(result))
 
-    for rowIdx, row := range result.Rows() {
-        cols := result.Columns(row)
+	for rowIdx, row := range result.Rows() {
+		cols := result.Columns(row)
 
-        blob, err := cols[blobIndex+2].GetBlob()
-        require.NoError(t, err)
-        assert.Equal(t, td.BlobPoints[rowIdx].Content(), blob)
+		blob, err := cols[blobIndex+2].GetBlob()
+		require.NoError(t, err)
+		assert.Equal(t, td.BlobPoints[rowIdx].Content(), blob)
 
-        dbl, err := cols[doubleIndex+2].GetDouble()
-        require.NoError(t, err)
-        assert.Equal(t, td.DoublePoints[rowIdx].Content(), dbl)
+		dbl, err := cols[doubleIndex+2].GetDouble()
+		require.NoError(t, err)
+		assert.Equal(t, td.DoublePoints[rowIdx].Content(), dbl)
 
-        i64, err := cols[int64Index+2].GetInt64()
-        require.NoError(t, err)
-        assert.Equal(t, td.Int64Points[rowIdx].Content(), i64)
+		i64, err := cols[int64Index+2].GetInt64()
+		require.NoError(t, err)
+		assert.Equal(t, td.Int64Points[rowIdx].Content(), i64)
 
-        str, err := cols[stringIndex+2].GetString()
-        require.NoError(t, err)
-        assert.Equal(t, td.StringPoints[rowIdx].Content(), str)
+		str, err := cols[stringIndex+2].GetString()
+		require.NoError(t, err)
+		assert.Equal(t, td.StringPoints[rowIdx].Content(), str)
 
-        ts, err := cols[timestampIndex+2].GetTimestamp()
-        require.NoError(t, err)
-        assert.Equal(t, td.TimestampPoints[rowIdx].Content(), ts)
+		ts, err := cols[timestampIndex+2].GetTimestamp()
+		require.NoError(t, err)
+		assert.Equal(t, td.TimestampPoints[rowIdx].Content(), ts)
 
-        sym, err := cols[symbolIndex+2].GetString()
-        require.NoError(t, err)
-        assert.Equal(t, td.SymbolPoints[rowIdx].Content(), sym)
+		sym, err := cols[symbolIndex+2].GetString()
+		require.NoError(t, err)
+		assert.Equal(t, td.SymbolPoints[rowIdx].Content(), sym)
 
-        // Universal getter validation
-        for i, c := range cols {
-            if i == 1 { // skip $table
-                continue
-            }
-            p := c.Get()
-            switch p.Type() {
-            case QueryResultBlob:
-                assert.Equal(t, td.BlobPoints[rowIdx].Content(), p.Value())
-            case QueryResultDouble:
-                assert.Equal(t, td.DoublePoints[rowIdx].Content(), p.Value())
-            case QueryResultInt64:
-                assert.Equal(t, td.Int64Points[rowIdx].Content(), p.Value())
-            case QueryResultString:
-                v := p.Value().(string)
-                exp1 := td.StringPoints[rowIdx].Content()
-                exp2 := td.SymbolPoints[rowIdx].Content()
-                assert.True(t, v == exp1 || v == exp2)
-            case QueryResultTimestamp:
-                assert.Equal(t, td.TimestampPoints[rowIdx].Content(), p.Value())
-            }
-        }
-    }
+		// Universal getter validation
+		for i, c := range cols {
+			if i == 1 { // skip $table
+				continue
+			}
+			p := c.Get()
+			switch p.Type() {
+			case QueryResultBlob:
+				assert.Equal(t, td.BlobPoints[rowIdx].Content(), p.Value())
+			case QueryResultDouble:
+				assert.Equal(t, td.DoublePoints[rowIdx].Content(), p.Value())
+			case QueryResultInt64:
+				assert.Equal(t, td.Int64Points[rowIdx].Content(), p.Value())
+			case QueryResultString:
+				v := p.Value().(string)
+				exp1 := td.StringPoints[rowIdx].Content()
+				exp2 := td.SymbolPoints[rowIdx].Content()
+				assert.True(t, v == exp1 || v == exp2)
+			case QueryResultTimestamp:
+				assert.Equal(t, td.TimestampPoints[rowIdx].Content(), p.Value())
+			}
+		}
+	}
 }
 
 func TestQueryInvalidQueryReturnsError(t *testing.T) {
-    handle := newTestHandle(t)
-    defer handle.Close()
+	handle := newTestHandle(t)
+	defer handle.Close()
 
-    _, err := handle.Query("select").Execute()
-    assert.Error(t, err)
+	_, err := handle.Query("select").Execute()
+	assert.Error(t, err)
 }
 
 func TestQueryWrongTypeReturnsError(t *testing.T) {
-    handle := newTestHandle(t)
-    defer handle.Close()
+	handle := newTestHandle(t)
+	defer handle.Close()
 
-    td := newTestTimeseriesAllColumns(t, handle, 1) // just 1 row needed
-    query := fmt.Sprintf("select * from %s in range(1970, +10d)", td.Alias)
-    result, err := handle.Query(query).Execute()
-    require.NoError(t, err)
-    defer handle.Release(unsafe.Pointer(result))
+	td := newTestTimeseriesAllColumns(t, handle, 1) // just 1 row needed
+	query := fmt.Sprintf("select * from %s in range(1970, +10d)", td.Alias)
+	result, err := handle.Query(query).Execute()
+	require.NoError(t, err)
+	defer handle.Release(unsafe.Pointer(result))
 
-    for _, row := range result.Rows() {
-        cols := result.Columns(row)
-        _, err := cols[blobIndex].GetDouble() // blob as double → error
-        assert.Error(t, err)
-    }
+	for _, row := range result.Rows() {
+		cols := result.Columns(row)
+		_, err := cols[blobIndex].GetDouble() // blob as double → error
+		assert.Error(t, err)
+	}
 }
 
 func TestQueryReturnsNoResults(t *testing.T) {
-    handle := newTestHandle(t)
-    defer handle.Close()
+	handle := newTestHandle(t)
+	defer handle.Close()
 
-    td := newTestTimeseriesAllColumns(t, handle, 4)
-    query := fmt.Sprintf("select * from %s in range(1971, +10d)", td.Alias)
-    result, err := handle.Query(query).Execute()
-    require.NoError(t, err)
-    assert.Equal(t, int64(0), result.ScannedPoints())
-    assert.Equal(t, int64(0), result.RowCount())
+	td := newTestTimeseriesAllColumns(t, handle, 4)
+	query := fmt.Sprintf("select * from %s in range(1971, +10d)", td.Alias)
+	result, err := handle.Query(query).Execute()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), result.ScannedPoints())
+	assert.Equal(t, int64(0), result.RowCount())
 }
 
 func TestQueryCreateTableReturnsNil(t *testing.T) {
-    handle := newTestHandle(t)
-    defer handle.Close()
+	handle := newTestHandle(t)
+	defer handle.Close()
 
-    alias := generateAlias(16)
-    result, err := handle.Query(
-        fmt.Sprintf("create table %s (id INT64, price DOUBLE)", alias),
-    ).Execute()
-    require.NoError(t, err)
-    assert.Nil(t, result)
+	alias := generateAlias(16)
+	result, err := handle.Query(
+		fmt.Sprintf("create table %s (id INT64, price DOUBLE)", alias),
+	).Execute()
+	require.NoError(t, err)
+	assert.Nil(t, result)
 
-    // cleanup
-    handle.Query(fmt.Sprintf("drop table %s", alias)).Execute()
+	// cleanup
+	handle.Query(fmt.Sprintf("drop table %s", alias)).Execute()
 }
 
 func TestQueryDropTableReturnsNil(t *testing.T) {
-    handle := newTestHandle(t)
-    defer handle.Close()
+	handle := newTestHandle(t)
+	defer handle.Close()
 
-    alias := generateAlias(16)
-    handle.Query(
-        fmt.Sprintf("create table %s (id INT64, price DOUBLE)", alias),
-    ).Execute()
+	alias := generateAlias(16)
+	handle.Query(
+		fmt.Sprintf("create table %s (id INT64, price DOUBLE)", alias),
+	).Execute()
 
-    result, err := handle.Query(
-        fmt.Sprintf("drop table %s", alias),
-    ).Execute()
-    require.NoError(t, err)
-    assert.Nil(t, result)
+	result, err := handle.Query(
+		fmt.Sprintf("drop table %s", alias),
+	).Execute()
+	require.NoError(t, err)
+	assert.Nil(t, result)
 }

--- a/reader.go
+++ b/reader.go
@@ -8,12 +8,12 @@ package qdb
    #include <qdb/ts.h>
 */
 import "C"
+
 import (
 	"fmt"
 	"time"
 	"unsafe"
 )
-
 
 // ReaderColumn: column metadata for reading
 type ReaderColumn struct {
@@ -23,13 +23,18 @@ type ReaderColumn struct {
 
 // NewReaderColumn creates column metadata.
 // Args:
-//   n: column name
-//   t: column type
+//
+//	n: column name
+//	t: column type
+//
 // Returns:
-//   ReaderColumn: metadata
-//   error: if invalid type
+//
+//	ReaderColumn: metadata
+//	error: if invalid type
+//
 // Example:
-//   col, err := NewReaderColumn("temp", TsColumnDouble)
+//
+//	col, err := NewReaderColumn("temp", TsColumnDouble)
 func NewReaderColumn(n string, t TsColumnType) (ReaderColumn, error) {
 	if t.IsValid() == false {
 		return ReaderColumn{}, fmt.Errorf("NewReaderColumn: invalid column: %v", t)
@@ -39,13 +44,18 @@ func NewReaderColumn(n string, t TsColumnType) (ReaderColumn, error) {
 
 // NewReaderColumnFromNative creates column from C types.
 // Args:
-//   n: C string name
-//   t: C column type
+//
+//	n: C string name
+//	t: C column type
+//
 // Returns:
-//   ReaderColumn: metadata
-//   error: if null name
+//
+//	ReaderColumn: metadata
+//	error: if null name
+//
 // Example:
-//   col, err := NewReaderColumnFromNative(cName, cType)
+//
+//	col, err := NewReaderColumnFromNative(cName, cType)
 func NewReaderColumnFromNative(n *C.char, t C.qdb_ts_column_type_t) (ReaderColumn, error) {
 	if n == nil {
 		return ReaderColumn{}, fmt.Errorf("NewReaderColumnFromNative: got null string reference for column name: %v", n)
@@ -59,18 +69,24 @@ func NewReaderColumnFromNative(n *C.char, t C.qdb_ts_column_type_t) (ReaderColum
 
 // Name returns column identifier.
 // Returns:
-//   string: column name
+//
+//	string: column name
+//
 // Example:
-//   name := col.Name() // → "temperature"
+//
+//	name := col.Name() // → "temperature"
 func (rc ReaderColumn) Name() string {
 	return rc.columnName
 }
 
 // Type returns column data type.
 // Returns:
-//   TsColumnType: data type
+//
+//	TsColumnType: data type
+//
 // Example:
-//   typ := col.Type() // → TsColumnDouble
+//
+//	typ := col.Type() // → TsColumnDouble
 func (rc ReaderColumn) Type() TsColumnType {
 	return rc.columnType
 }
@@ -108,9 +124,12 @@ func NewReaderChunk(cols []ReaderColumn, idx []time.Time, data []ColumnData) (Re
 
 // Empty checks if chunk has no data.
 // Returns:
-//   bool: true if empty
+//
+//	bool: true if empty
+//
 // Example:
-//   isEmpty := chunk.Empty() // → false
+//
+//	isEmpty := chunk.Empty() // → false
 func (rc *ReaderChunk) Empty() bool {
 	// Returns true if no data
 	return rc.idx == nil || len(rc.idx) == 0 || rc.data == nil || len(rc.data) == 0
@@ -118,7 +137,8 @@ func (rc *ReaderChunk) Empty() bool {
 
 // Clear resets chunk to empty state.
 // Example:
-//   chunk.Clear() // all data removed
+//
+//	chunk.Clear() // all data removed
 func (rc *ReaderChunk) Clear() {
 	// Empty slice
 	rc.idx = make([]time.Time, 0)
@@ -130,9 +150,12 @@ func (rc *ReaderChunk) Clear() {
 
 // EnsureCapacity pre-allocates space.
 // Args:
-//   n: minimum capacity
+//
+//	n: minimum capacity
+//
 // Example:
-//   chunk.EnsureCapacity(1000) // ready for 1000 rows
+//
+//	chunk.EnsureCapacity(1000) // ready for 1000 rows
 func (rc *ReaderChunk) EnsureCapacity(n int) {
 	rc.idx = sliceEnsureCapacity(rc.idx, n)
 
@@ -145,9 +168,12 @@ func (rc *ReaderChunk) EnsureCapacity(n int) {
 
 // RowCount returns rows in chunk.
 // Returns:
-//   int: row count
+//
+//	int: row count
+//
 // Example:
-//   n := chunk.RowCount() // → 1000
+//
+//	n := chunk.RowCount() // → 1000
 func (rc *ReaderChunk) RowCount() int {
 	return len(rc.idx)
 }
@@ -230,7 +256,8 @@ func mergeReaderChunks(xs []ReaderChunk) (ReaderChunk, error) {
 	return ReaderChunk{
 		idx:                mergedIdx,
 		data:               mergedData,
-		columnInfoByOffset: base.columnInfoByOffset}, nil
+		columnInfoByOffset: base.columnInfoByOffset,
+	}, nil
 }
 
 // newReaderChunk converts the native C table representation into a Go ReaderChunk.
@@ -248,7 +275,6 @@ func mergeReaderChunks(xs []ReaderChunk) (ReaderChunk, error) {
 //   - Copies all row data into Go slices for safety; incurs O(n) allocation but
 //     ensures lifetime independence from the C buffer.
 func newReaderChunk(columns []ReaderColumn, data C.qdb_exp_batch_push_table_data_t) (ReaderChunk, error) {
-
 	if data.timestamps == nil {
 		return ReaderChunk{}, fmt.Errorf("Internal error: nil timestamps")
 	}
@@ -365,11 +391,16 @@ func NewReaderOptions() ReaderOptions {
 
 // NewReaderDefaultOptions creates options for full table read.
 // Args:
-//   tables: table names to read
+//
+//	tables: table names to read
+//
 // Returns:
-//   ReaderOptions: configured for all data
+//
+//	ReaderOptions: configured for all data
+//
 // Example:
-//   opts := NewReaderDefaultOptions([]string{"metrics"})
+//
+//	opts := NewReaderDefaultOptions([]string{"metrics"})
 func NewReaderDefaultOptions(tables []string) ReaderOptions {
 	return NewReaderOptions().WithTables(tables)
 }
@@ -395,7 +426,7 @@ func (ro ReaderOptions) WithColumns(columns []string) ReaderOptions {
 }
 
 // WithTimeRange restricts reads to the given half-open interval [start, end).
-func (ro ReaderOptions) WithTimeRange(start time.Time, end time.Time) ReaderOptions {
+func (ro ReaderOptions) WithTimeRange(start, end time.Time) ReaderOptions {
 	ro.rangeStart = start
 	ro.rangeEnd = end
 
@@ -562,7 +593,6 @@ func NewReader(h HandleType, options ReaderOptions) (Reader, error) {
 	)
 
 	err = makeErrorOrNil(errCode)
-
 	if err != nil {
 		return ret, err
 	}
@@ -598,14 +628,14 @@ func (r *Reader) fetchBatch() (ReaderChunk, error) {
 
 	// Time the C API call
 	start := time.Now()
-	
+
 	// qdb_bulk_reader_get_data "fills" a pointer in style of when you would get data back
 	// for a number of tables, but it returns just a pointer for a single table. all memory
 	// allocated within this function call is linked to this single object, and a qdbRelease
 	// clears eerything
 	errCode := C.qdb_bulk_reader_get_data(r.state, &ptr, C.qdb_size_t(r.options.batchSize))
 	err := makeErrorOrNil(errCode)
-	
+
 	elapsed := time.Since(start)
 
 	// Trigger the `defer` statement as there are failure scenarios in both cases where err
@@ -644,7 +674,6 @@ func (r *Reader) fetchBatch() (ReaderChunk, error) {
 	cols := make([]ReaderColumn, colCount)
 	for j := range colCount {
 		cols[j], err = NewReaderColumnFromNative(colSlice[j].name, colSlice[j].data_type)
-
 		if err != nil {
 			return ret, err
 		}
@@ -658,7 +687,7 @@ func (r *Reader) fetchBatch() (ReaderChunk, error) {
 	// Log the batch read performance
 	rowCount := ret.RowCount()
 	L().Debug("read batch of rows", "count", rowCount, "duration", elapsed)
-	
+
 	return ret, nil
 }
 
@@ -739,7 +768,8 @@ func (r *Reader) FetchAll() (ReaderChunk, error) {
 
 // Close releases reader resources.
 // Example:
-//   defer reader.Close()
+//
+//	defer reader.Close()
 func (r *Reader) Close() {
 	// if state is non-nil, invoke qdbRelease() on state
 	if r.state != nil {
@@ -748,5 +778,4 @@ func (r *Reader) Close() {
 
 		r.state = nil
 	}
-
 }

--- a/reader.go
+++ b/reader.go
@@ -592,7 +592,7 @@ func NewReader(h HandleType, options ReaderOptions) (Reader, error) {
 		&readerHandle,
 	)
 
-	err = makeErrorOrNil(errCode)
+	err = wrapError(errCode, "reader_init", "tables", tableCount)
 	if err != nil {
 		return ret, err
 	}
@@ -634,7 +634,7 @@ func (r *Reader) fetchBatch() (ReaderChunk, error) {
 	// allocated within this function call is linked to this single object, and a qdbRelease
 	// clears eerything
 	errCode := C.qdb_bulk_reader_get_data(r.state, &ptr, C.qdb_size_t(r.options.batchSize))
-	err := makeErrorOrNil(errCode)
+	err := wrapError(errCode, "reader_fetch_batch", "batch_size", r.options.batchSize)
 
 	elapsed := time.Since(start)
 

--- a/reader.go
+++ b/reader.go
@@ -1,4 +1,7 @@
-// Package qdb provides an api to a quasardb server
+// Copyright (c) 2009-2025, quasardb SAS. All rights reserved.
+// Package qdb: QuasarDB Go client API
+// Types: Reader, Writer, ColumnData, HandleType
+// Ex: h.NewReader(opts).FetchAll() → batch
 package qdb
 
 /*
@@ -15,26 +18,13 @@ import (
 	"unsafe"
 )
 
-// ReaderColumn: column metadata for reading
+// ReaderColumn holds column metadata for reading.
 type ReaderColumn struct {
-	columnName string
-	columnType TsColumnType
+	columnName string       // column identifier
+	columnType TsColumnType // data type
 }
 
 // NewReaderColumn creates column metadata.
-// Args:
-//
-//	n: column name
-//	t: column type
-//
-// Returns:
-//
-//	ReaderColumn: metadata
-//	error: if invalid type
-//
-// Example:
-//
-//	col, err := NewReaderColumn("temp", TsColumnDouble)
 func NewReaderColumn(n string, t TsColumnType) (ReaderColumn, error) {
 	if t.IsValid() == false {
 		return ReaderColumn{}, fmt.Errorf("NewReaderColumn: invalid column: %v", t)
@@ -43,19 +33,6 @@ func NewReaderColumn(n string, t TsColumnType) (ReaderColumn, error) {
 }
 
 // NewReaderColumnFromNative creates column from C types.
-// Args:
-//
-//	n: C string name
-//	t: C column type
-//
-// Returns:
-//
-//	ReaderColumn: metadata
-//	error: if null name
-//
-// Example:
-//
-//	col, err := NewReaderColumnFromNative(cName, cType)
 func NewReaderColumnFromNative(n *C.char, t C.qdb_ts_column_type_t) (ReaderColumn, error) {
 	if n == nil {
 		return ReaderColumn{}, fmt.Errorf("NewReaderColumnFromNative: got null string reference for column name: %v", n)
@@ -67,31 +44,17 @@ func NewReaderColumnFromNative(n *C.char, t C.qdb_ts_column_type_t) (ReaderColum
 	}, nil
 }
 
-// Name returns column identifier.
-// Returns:
-//
-//	string: column name
-//
-// Example:
-//
-//	name := col.Name() // → "temperature"
+// Name returns the column name.
 func (rc ReaderColumn) Name() string {
 	return rc.columnName
 }
 
-// Type returns column data type.
-// Returns:
-//
-//	TsColumnType: data type
-//
-// Example:
-//
-//	typ := col.Type() // → TsColumnDouble
+// Type returns the column data type.
 func (rc ReaderColumn) Type() TsColumnType {
 	return rc.columnType
 }
 
-// ReaderChunk: batch of rows read from table
+// ReaderChunk holds a batch of rows read from table.
 type ReaderChunk struct {
 	// An index that enables looking up of a column's name by its offset within the table.
 	columnInfoByOffset []ReaderColumn
@@ -103,17 +66,7 @@ type ReaderChunk struct {
 	data []ColumnData
 }
 
-// NewReaderChunk constructs a ReaderChunk from explicit column metadata,
-// index values and column data slices.
-//
-// Decision rationale:
-//   - Separates validation from data copying, enabling reuse in tests and
-//     production code.
-//
-// Key assumptions:
-//   - len(cols) == len(data).
-//   - len(idx) matches data[i].Length() for each column.
-//   - Callers validate these preconditions; TODO above indicates missing checks.
+// NewReaderChunk creates a chunk from columns, index, and data.
 func NewReaderChunk(cols []ReaderColumn, idx []time.Time, data []ColumnData) (ReaderChunk, error) {
 	return ReaderChunk{
 		columnInfoByOffset: cols,
@@ -122,23 +75,13 @@ func NewReaderChunk(cols []ReaderColumn, idx []time.Time, data []ColumnData) (Re
 	}, nil
 }
 
-// Empty checks if chunk has no data.
-// Returns:
-//
-//	bool: true if empty
-//
-// Example:
-//
-//	isEmpty := chunk.Empty() // → false
+// Empty reports if the chunk has no data.
 func (rc *ReaderChunk) Empty() bool {
 	// Returns true if no data
 	return rc.idx == nil || len(rc.idx) == 0 || rc.data == nil || len(rc.data) == 0
 }
 
-// Clear resets chunk to empty state.
-// Example:
-//
-//	chunk.Clear() // all data removed
+// Clear resets the chunk to empty state.
 func (rc *ReaderChunk) Clear() {
 	// Empty slice
 	rc.idx = make([]time.Time, 0)
@@ -148,14 +91,7 @@ func (rc *ReaderChunk) Clear() {
 	}
 }
 
-// EnsureCapacity pre-allocates space.
-// Args:
-//
-//	n: minimum capacity
-//
-// Example:
-//
-//	chunk.EnsureCapacity(1000) // ready for 1000 rows
+// EnsureCapacity pre-allocates space for n rows.
 func (rc *ReaderChunk) EnsureCapacity(n int) {
 	rc.idx = sliceEnsureCapacity(rc.idx, n)
 
@@ -166,29 +102,12 @@ func (rc *ReaderChunk) EnsureCapacity(n int) {
 	}
 }
 
-// RowCount returns rows in chunk.
-// Returns:
-//
-//	int: row count
-//
-// Example:
-//
-//	n := chunk.RowCount() // → 1000
+// RowCount returns the number of rows in the chunk.
 func (rc *ReaderChunk) RowCount() int {
 	return len(rc.idx)
 }
 
-// mergeReaderChunks merges multiple chunks of the same table into one unified chunk.
-//
-// Decision rationale:
-//   - Consolidates batch iteration results into a single structure for simpler
-//     comparison and verification.
-//
-// Key assumptions:
-//   - xs is non-empty and all chunks share identical schemas.
-//
-// Performance trade-offs:
-//   - Requires copying all row data once; acceptable for test sizes.
+// mergeReaderChunks combines multiple chunks into one.
 func mergeReaderChunks(xs []ReaderChunk) (ReaderChunk, error) {
 	if len(xs) == 0 {
 		return ReaderChunk{}, nil
@@ -260,20 +179,7 @@ func mergeReaderChunks(xs []ReaderChunk) (ReaderChunk, error) {
 	}, nil
 }
 
-// newReaderChunk converts the native C table representation into a Go ReaderChunk.
-//
-// Decision rationale:
-//   - Encapsulates the logic for translating C types and copying data into
-//     Go-managed memory.
-//
-// Key assumptions:
-//   - `columns` describes the schema encoded in `data`.
-//   - `data` originates from qdb_exp_batch_push_table_data_t with valid pointers
-//     and counts.
-//
-// Performance trade-offs:
-//   - Copies all row data into Go slices for safety; incurs O(n) allocation but
-//     ensures lifetime independence from the C buffer.
+// newReaderChunk converts C table data to Go ReaderChunk.
 func newReaderChunk(columns []ReaderColumn, data C.qdb_exp_batch_push_table_data_t) (ReaderChunk, error) {
 	if data.timestamps == nil {
 		return ReaderChunk{}, fmt.Errorf("Internal error: nil timestamps")
@@ -353,35 +259,16 @@ func newReaderChunk(columns []ReaderColumn, data C.qdb_exp_batch_push_table_data
 	return out, nil
 }
 
-// ReaderOptions: bulk read configuration
+// ReaderOptions configures bulk read operations.
 type ReaderOptions struct {
-	batchSize  int
-	tables     []string
-	columns    []string
-	rangeStart time.Time
-	rangeEnd   time.Time
+	batchSize  int       // max rows per fetch
+	tables     []string  // tables to read
+	columns    []string  // columns to read
+	rangeStart time.Time // range start (inclusive)
+	rangeEnd   time.Time // range end (exclusive)
 }
 
-// NewReaderOptions creates a new ReaderOptions value with default settings.
-//
-// ReaderOptions uses the builder pattern to make configuration flexible and readable.
-// You typically create an options value with NewReaderOptions, and then chain one or more
-// configuration methods like WithTables, WithColumns, WithBatchSize, and WithTimeRange.
-//
-// Example usage:
-//
-//	opts := NewReaderOptions().
-//	    WithTables([]string{"table1", "table2"}).
-//	    WithColumns([]string{"colA", "colB"}).
-//	    WithBatchSize(10000).
-//	    WithTimeRange(startTime, endTime)
-//
-// This options value can then be passed to NewReader to create a Reader
-// instance:
-//
-//	reader, err := NewReader(handle, opts)
-//
-// See WithTables, WithColumns, WithBatchSize, and WithTimeRange for configuration details.
+// NewReaderOptions creates reader options with defaults.
 func NewReaderOptions() ReaderOptions {
 	// Default to 32768 rows
 	var defaultBatchSize int = 32 * 1024
@@ -389,43 +276,30 @@ func NewReaderOptions() ReaderOptions {
 	return ReaderOptions{batchSize: defaultBatchSize}
 }
 
-// NewReaderDefaultOptions creates options for full table read.
-// Args:
-//
-//	tables: table names to read
-//
-// Returns:
-//
-//	ReaderOptions: configured for all data
-//
-// Example:
-//
-//	opts := NewReaderDefaultOptions([]string{"metrics"})
+// NewReaderDefaultOptions creates options for reading entire tables.
 func NewReaderDefaultOptions(tables []string) ReaderOptions {
 	return NewReaderOptions().WithTables(tables)
 }
 
-// WithBatchSize specifies the maximum rows returned per fetch.
-// Use smaller sizes to limit memory usage at the cost of more network calls.
+// WithBatchSize sets max rows per fetch.
 func (ro ReaderOptions) WithBatchSize(batchSize int) ReaderOptions {
 	ro.batchSize = batchSize
 	return ro
 }
 
-// WithTables restricts the reader to the provided table names.
+// WithTables sets tables to read.
 func (ro ReaderOptions) WithTables(tables []string) ReaderOptions {
 	ro.tables = tables
 	return ro
 }
 
-// WithColumns limits which columns are read from each table.
-// An empty slice implies all columns.
+// WithColumns sets columns to read (empty=all).
 func (ro ReaderOptions) WithColumns(columns []string) ReaderOptions {
 	ro.columns = columns
 	return ro
 }
 
-// WithTimeRange restricts reads to the given half-open interval [start, end).
+// WithTimeRange sets time range [start, end).
 func (ro ReaderOptions) WithTimeRange(start, end time.Time) ReaderOptions {
 	ro.rangeStart = start
 	ro.rangeEnd = end
@@ -433,7 +307,7 @@ func (ro ReaderOptions) WithTimeRange(start, end time.Time) ReaderOptions {
 	return ro
 }
 
-// Reader: iterator for bulk data retrieval
+// Reader iterates over bulk data from QuasarDB.
 type Reader struct {
 	// Handle that was used to create the reader, and should be reused accross all additional
 	// calls (specifically all memory allocations and/or qdb_release() invocations) in the scope
@@ -457,31 +331,7 @@ type Reader struct {
 	currentBatch ReaderChunk
 }
 
-// NewReader returns a new Reader instance that allows bulk data retrieval from quasardb tables.
-//
-// Typical usage for retrieving data involves iteration like this:
-//
-//	reader := NewReader(options)
-//	defer reader.Close()
-//	for reader.Next() {
-//	    batch := reader.Batch()
-//	    // process batch
-//	}
-//	if err := reader.Err(); err != nil {
-//	    // handle error appropriately
-//	}
-//
-// To conveniently retrieve all available data as a single batch:
-//
-//	reader := NewReader(options)
-//	defer reader.Close()
-//	batch, err := reader.FetchAll()
-//	if err != nil {
-//	    // handle error appropriately
-//	}
-//	// process batch
-//
-// Always call reader.Close() to release any associated resources.
+// NewReader creates a reader for bulk data retrieval.
 func NewReader(h HandleType, options ReaderOptions) (Reader, error) {
 	var ret Reader
 	ret.handle = h
@@ -604,24 +454,7 @@ func NewReader(h HandleType, options ReaderOptions) (Reader, error) {
 	return ret, nil
 }
 
-// fetchBatch retrieves up to r.options.batchSize rows from the server.
-//
-// Decision rationale:
-//   - Wraps the qdb_bulk_reader_get_data call and converts the native format
-//     to a Go ReaderChunk.
-//
-// Key assumptions:
-//   - r.state is a valid reader handle.
-//   - Caller handles ErrIteratorEnd appropriately.
-//
-// Performance trade-offs:
-//   - Allocates new slices for column data each call; acceptable for test-sized
-//     batches but avoid for extremely large data sets.
-//
-// Usage example:
-//
-//	batch, err := r.fetchBatch()
-//	if err != nil { /* handle */ }
+// fetchBatch retrieves the next batch of rows.
 func (r *Reader) fetchBatch() (ReaderChunk, error) {
 	var ret ReaderChunk
 	var ptr *C.qdb_bulk_reader_table_data_t
@@ -691,13 +524,7 @@ func (r *Reader) fetchBatch() (ReaderChunk, error) {
 	return ret, nil
 }
 
-// Next prepares the next available data batch.
-// It returns true if more data is available, false otherwise, making it suitable
-// for idiomatic Go loops:
-//
-//	for reader.Next() { ... }
-//
-// Always use Err() afterward to check if iteration ended due to an error.
+// Next advances to the next batch, returns false when done.
 func (r *Reader) Next() bool {
 	if r.done {
 		return false
@@ -713,30 +540,17 @@ func (r *Reader) Next() bool {
 	return true
 }
 
-// Err returns the error encountered during iteration, if any.
-// After a completed iteration with Next(), Err() must be checked to
-// distinguish between successful completion and errors during reading.
+// Err returns any error from iteration.
 func (r *Reader) Err() error {
 	return r.err
 }
 
-// Batch returns the current batch of data prepared by Next().
-// It's designed to be called within a Next() loop:
-//
-//	for reader.Next() {
-//	    batch := reader.Batch()
-//	    // use batch
-//	}
+// Batch returns the current batch.
 func (r *Reader) Batch() ReaderChunk {
 	return r.currentBatch
 }
 
-// FetchAll retrieves the entire dataset as a single batch to simplify interaction when the entire result set is required.
-//
-// It internally manages batching and merging of data, eliminating the need for callers to iterate manually.
-//
-// Important: Consider memory usage carefully — FetchAll may consume significant resources when reading large datasets.
-// Use this function when convenience outweighs potential memory overhead.
+// FetchAll retrieves all data as a single batch.
 func (r *Reader) FetchAll() (ReaderChunk, error) {
 	// Accumulate all batches from the reader's iterator, and merges them together in a single
 	// batch.
@@ -767,9 +581,6 @@ func (r *Reader) FetchAll() (ReaderChunk, error) {
 }
 
 // Close releases reader resources.
-// Example:
-//
-//	defer reader.Close()
 func (r *Reader) Close() {
 	// if state is non-nil, invoke qdbRelease() on state
 	if r.state != nil {

--- a/statistics.go
+++ b/statistics.go
@@ -4,6 +4,7 @@ package qdb
 	#include <qdb/client.h>
 */
 import "C"
+
 import (
 	"bytes"
 	"fmt"
@@ -29,7 +30,7 @@ type Statistics struct {
 	} `json:"memory"`
 	Network struct {
 		CurrentUsersCount int64 `json:"current_users_count"`
-		PartitionsCount int64  `json:"partitions_count"`
+		PartitionsCount   int64 `json:"partitions_count"`
 		Sessions          struct {
 			AvailableCount   int64 `json:"available_count"`
 			UnavailableCount int64 `json:"unavailable_count"`
@@ -39,8 +40,8 @@ type Statistics struct {
 	NodeID          string `json:"chord.node_id"`
 	OperatingSystem string `json:"operating_system"`
 	Persistence     struct {
-		BytesRead     int64 `json:"read_bytes"`
-		BytesWritten  int64 `json:"written_bytes"`
+		BytesRead    int64 `json:"read_bytes"`
+		BytesWritten int64 `json:"written_bytes"`
 	} `json:"persistence"`
 	Requests struct {
 		BytesOut       int64 `json:"out_bytes"`
@@ -107,7 +108,6 @@ func (h HandleType) Statistics() (map[string]Statistics, error) {
 	results := map[string]Statistics{}
 
 	endpoints, err := h.Cluster().Endpoints()
-
 	if err != nil {
 		return results, err
 	}
@@ -115,13 +115,11 @@ func (h HandleType) Statistics() (map[string]Statistics, error) {
 	for _, endpoint := range endpoints {
 		uri := endpoint.URI()
 		dh, err := h.DirectConnect(uri)
-
 		if err != nil {
 			return results, err
 		}
 
 		stats, err := dh.nodeStatistics()
-
 		if err != nil {
 			return results, err
 		}

--- a/statistics_test.go
+++ b/statistics_test.go
@@ -3,6 +3,7 @@ package qdb
 import (
 	"testing"
 	"time"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/test_utils.go
+++ b/test_utils.go
@@ -170,6 +170,7 @@ func columnNamesFromWriterColumns(cols []WriterColumn) []string {
 	for i, c := range cols {
 		names[i] = c.ColumnName
 	}
+
 	return names
 }
 
@@ -182,6 +183,7 @@ func writerTableNames(tables []WriterTable) []string {
 	for i, wt := range tables {
 		names[i] = wt.GetName()
 	}
+
 	return names
 }
 
@@ -192,6 +194,7 @@ func writerTableNames(tables []WriterTable) []string {
 func writerTableColumns(table WriterTable) []WriterColumn {
 	cols := make([]WriterColumn, len(table.columnInfoByOffset))
 	copy(cols, table.columnInfoByOffset)
+
 	return cols
 }
 
@@ -203,6 +206,7 @@ func writerTablesColumns(tables []WriterTable) []WriterColumn {
 	if len(tables) == 0 {
 		panic("writerTablesColumns called with no tables")
 	}
+
 	return writerTableColumns(tables[0])
 }
 
@@ -224,6 +228,7 @@ func writerTablesColumns(tables []WriterTable) []WriterColumn {
 //	col := genWriterColumnOfType(rt, TsColumnInt64)
 func genWriterColumnOfType(t *rapid.T, ctype TsColumnType) WriterColumn {
 	name := rapid.StringMatching(`[a-zA-Z]{8}`).Draw(t, "writerColumnName")
+
 	return WriterColumn{ColumnName: name, ColumnType: ctype}
 }
 
@@ -242,6 +247,7 @@ func genWriterColumnOfType(t *rapid.T, ctype TsColumnType) WriterColumn {
 //	col := genWriterColumn(rt)
 func genWriterColumn(t *rapid.T) WriterColumn {
 	ctype := rapid.SampledFrom(columnTypes[:]).Draw(t, "writerColumnType")
+
 	return genWriterColumnOfType(t, ctype)
 }
 
@@ -283,6 +289,7 @@ func genWriterColumnsOfAllTypes(t *rapid.T) []WriterColumn {
 	for i, ctype := range columnTypes {
 		cols[i] = genWriterColumnOfType(t, ctype)
 	}
+
 	return cols
 }
 
@@ -319,6 +326,7 @@ func genIndexAscending(t *rapid.T, rowCount int) []time.Time {
 	for i := range rowCount {
 		idx[i] = start.Add(time.Duration(stepNs * int64(i)))
 	}
+
 	return idx
 }
 
@@ -328,6 +336,7 @@ func genWriterDataInt64(t *rapid.T, rowCount int) ColumnData {
 		values[i] = rapid.Int64().Draw(t, "int64")
 	}
 	cd := NewColumnDataInt64(values)
+
 	return &cd
 }
 
@@ -337,6 +346,7 @@ func genWriterDataDouble(t *rapid.T, rowCount int) ColumnData {
 		values[i] = rapid.Float64().Draw(t, "float64")
 	}
 	cd := NewColumnDataDouble(values)
+
 	return &cd
 }
 
@@ -346,6 +356,7 @@ func genWriterDataTimestamp(t *rapid.T, rowCount int) ColumnData {
 		values[i] = genTime(t)
 	}
 	cd := NewColumnDataTimestamp(values)
+
 	return &cd
 }
 
@@ -355,6 +366,7 @@ func genWriterDataBlob(t *rapid.T, rowCount int) ColumnData {
 		values[i] = rapid.SliceOfN(rapid.Byte(), 1, 64).Draw(t, "blob")
 	}
 	cd := NewColumnDataBlob(values)
+
 	return &cd
 }
 
@@ -364,6 +376,7 @@ func genWriterDataString(t *rapid.T, rowCount int) ColumnData {
 		values[i] = rapid.StringN(1, 32, 64).Draw(t, "string")
 	}
 	cd := NewColumnDataString(values)
+
 	return &cd
 }
 
@@ -388,6 +401,7 @@ func genWriterDatas(t *rapid.T, rowCount int, columns []WriterColumn) []ColumnDa
 	for i, col := range columns {
 		datas[i] = genWriterData(t, rowCount, col.ColumnType)
 	}
+
 	return datas
 }
 
@@ -425,6 +439,7 @@ func genPopulatedTables(t *rapid.T, handle HandleType) []WriterTable {
 
 		tables[i] = wt
 	}
+
 	return tables
 }
 
@@ -448,6 +463,7 @@ func genPopulatedTables(t *rapid.T, handle HandleType) []WriterTable {
 func genTime(t *rapid.T) time.Time {
 	sec := rapid.Int64Range(0, 8_147_483_646).Draw(t, "sec")
 	nsec := rapid.Int64Range(0, 999_999_999).Draw(t, "nsec")
+
 	return time.Unix(sec, nsec).UTC()
 }
 
@@ -545,6 +561,7 @@ func genReaderColumns(t *rapid.T) []ReaderColumn {
 //	rd := genReaderData(t) // ReaderData with random schema and data
 func genReaderData(t *rapid.T) ColumnData {
 	rowCount := rapid.IntRange(1, 1024).Draw(t, "rowCount")
+
 	return genReaderDataOfRowCount(t, rowCount)
 }
 
@@ -631,6 +648,7 @@ func genReaderDataInt64(t *rapid.T, name string, rowCount int) *ColumnDataInt64 
 	}
 
 	ret := NewColumnDataInt64(values)
+
 	return &ret
 }
 
@@ -658,6 +676,7 @@ func genReaderDataDouble(t *rapid.T, name string, rowCount int) *ColumnDataDoubl
 	}
 
 	ret := NewColumnDataDouble(values)
+
 	return &ret
 }
 
@@ -685,6 +704,7 @@ func genReaderDataTimestamp(t *rapid.T, name string, rowCount int) *ColumnDataTi
 	}
 
 	ret := NewColumnDataTimestamp(values)
+
 	return &ret
 }
 
@@ -712,6 +732,7 @@ func genReaderDataBlob(t *rapid.T, name string, rowCount int) *ColumnDataBlob {
 	}
 
 	ret := NewColumnDataBlob(values)
+
 	return &ret
 }
 
@@ -741,6 +762,7 @@ func genReaderDataString(t *rapid.T, name string, rowCount int) *ColumnDataStrin
 	}
 
 	ret := NewColumnDataString(values)
+
 	return &ret
 }
 
@@ -834,6 +856,7 @@ func genReaderChunks(t *rapid.T) []ReaderChunk {
 	})
 
 	genChunks := rapid.SliceOfN(genChunk, 1, 8)
+
 	return genChunks.Draw(t, "readerChunks")
 }
 
@@ -864,6 +887,7 @@ func generateTags(n int) []string {
 	for i := range ret {
 		ret[i] = generateAlias(16)
 	}
+
 	return ret
 }
 
@@ -887,6 +911,7 @@ func createTempFile(t *testing.T, prefix, content string) string {
 	name := fmt.Sprintf("%s_%s.tmp", prefix, generateAlias(8))
 	require.NoError(t, os.WriteFile(name, []byte(content), 0o600))
 	t.Cleanup(func() { os.Remove(name) })
+
 	return name
 }
 
@@ -1231,7 +1256,7 @@ func newTestTimeseriesAllColumns(t *testing.T, handle HandleType, count int64) T
 	timestampPoints := make([]TsTimestampPoint, count)
 	symbolPoints := make([]TsStringPoint, count)
 
-	for i := int64(0); i < count; i++ {
+	for i := range count {
 		tsVal := time.Unix((i+1)*10, 0)
 		timestamps[i] = tsVal
 		blobPoints[i] = NewTsBlobPoint(tsVal, []byte(fmt.Sprintf("content_%d", i)))
@@ -1293,7 +1318,7 @@ func createDoubleTimeseriesWithPoints(
 	if count > 0 {
 		timestamps = make([]time.Time, count)
 		points = make([]TsDoublePoint, count)
-		for i := int64(0); i < count; i++ {
+		for i := range count {
 			tsVal := time.Unix((i+1)*10, 0)
 			timestamps[i] = tsVal
 			points[i] = NewTsDoublePoint(tsVal, float64(i))
@@ -1335,7 +1360,7 @@ func createInt64TimeseriesWithPoints(
 	if count > 0 {
 		timestamps = make([]time.Time, count)
 		points = make([]TsInt64Point, count)
-		for i := int64(0); i < count; i++ {
+		for i := range count {
 			tsVal := time.Unix((i+1)*10, 0)
 			timestamps[i] = tsVal
 			points[i] = NewTsInt64Point(tsVal, i)

--- a/time.go
+++ b/time.go
@@ -5,6 +5,7 @@ package qdb
 	#include <qdb/ts.h>
 */
 import "C"
+
 import (
 	"time"
 )
@@ -29,7 +30,7 @@ func toQdbTime(tp time.Time) C.qdb_time_t {
 }
 
 // toQdbRange builds a qdb_ts_range_t from begin and end times.
-func toQdbRange(begin time.Time, end time.Time) C.qdb_ts_range_t {
+func toQdbRange(begin, end time.Time) C.qdb_ts_range_t {
 	var ret C.qdb_ts_range_t
 	ret.begin = toQdbTimespec(begin)
 	ret.end = toQdbTimespec(end)

--- a/time_test.go
+++ b/time_test.go
@@ -14,7 +14,6 @@ func TestTimeCanConvertToQdbTimespec(t *testing.T) {
 	genTimes := rapid.SliceOf(rapid.Custom(genTime))
 
 	rapid.Check(t, func(t *rapid.T) {
-
 		// Generate a random set of times
 		input := genTimes.Draw(t, "times")
 

--- a/writer.go
+++ b/writer.go
@@ -205,7 +205,7 @@ func (w *Writer) Push(h HandleType) error {
 		L().Info("wrote rows", "count", totalRows, "duration", elapsed)
 	}
 
-	return makeErrorOrNil(C.qdb_error_t(errCode))
+	return wrapError(C.qdb_error_t(errCode), "writer_write", "tables", len(tblSlice))
 }
 
 // writerTableSchemasEqual compares table schemas.

--- a/writer.go
+++ b/writer.go
@@ -14,8 +14,9 @@ import (
 
 // WriterColumn: metadata for single column.
 // Fields:
-//   ColumnName: identifier
-//   ColumnType: data type
+//
+//	ColumnName: identifier
+//	ColumnType: data type
 type WriterColumn struct {
 	ColumnName string
 	ColumnType TsColumnType
@@ -23,8 +24,9 @@ type WriterColumn struct {
 
 // Writer: batches tables for push.
 // Fields:
-//   options: push configuration
-//   tables: name→WriterTable map
+//
+//	options: push configuration
+//	tables: name→WriterTable map
 type Writer struct {
 	options WriterOptions
 	tables  map[string]WriterTable
@@ -32,40 +34,56 @@ type Writer struct {
 
 // NewWriter creates writer with options.
 // Args:
-//   options: push configuration
+//
+//	options: push configuration
+//
 // Returns:
-//   Writer: configured writer
+//
+//	Writer: configured writer
+//
 // Example:
-//   w := NewWriter(opts) // → Writer{opts, empty map}
+//
+//	w := NewWriter(opts) // → Writer{opts, empty map}
 func NewWriter(options WriterOptions) Writer {
 	return Writer{options: options, tables: make(map[string]WriterTable)}
 }
 
 // NewWriterWithDefaultOptions creates writer with defaults.
 // Returns:
-//   Writer: default configuration
+//
+//	Writer: default configuration
+//
 // Example:
-//   w := NewWriterWithDefaultOptions() // → Writer{default opts}
+//
+//	w := NewWriterWithDefaultOptions() // → Writer{default opts}
 func NewWriterWithDefaultOptions() Writer {
 	return NewWriter(NewWriterOptions())
 }
 
 // GetOptions returns push configuration.
 // Returns:
-//   WriterOptions: current options
+//
+//	WriterOptions: current options
+//
 // Example:
-//   opts := w.GetOptions() // → WriterOptions
+//
+//	opts := w.GetOptions() // → WriterOptions
 func (w *Writer) GetOptions() WriterOptions {
 	return w.options
 }
 
 // SetTable adds table to batch.
 // Args:
-//   t: table to add
+//
+//	t: table to add
+//
 // Returns:
-//   error: if exists or schema mismatch
+//
+//	error: if exists or schema mismatch
+//
 // Example:
-//   err := w.SetTable(tbl) // → nil or error
+//
+//	err := w.SetTable(tbl) // → nil or error
 func (w *Writer) SetTable(t WriterTable) error {
 	tableName := t.GetName()
 
@@ -91,12 +109,17 @@ func (w *Writer) SetTable(t WriterTable) error {
 
 // GetTable retrieves table by name.
 // Args:
-//   name: table identifier
+//
+//	name: table identifier
+//
 // Returns:
-//   WriterTable: found table
-//   error: if not found
+//
+//	WriterTable: found table
+//	error: if not found
+//
 // Example:
-//   tbl, err := w.GetTable("my_table") // → WriterTable or error
+//
+//	tbl, err := w.GetTable("my_table") // → WriterTable or error
 func (w *Writer) GetTable(name string) (WriterTable, error) {
 	t, ok := w.tables[name]
 	if !ok {
@@ -108,20 +131,28 @@ func (w *Writer) GetTable(name string) (WriterTable, error) {
 
 // Length returns table count.
 // Returns:
-//   int: number of tables
+//
+//	int: number of tables
+//
 // Example:
-//   n := w.Length() // → 3
+//
+//	n := w.Length() // → 3
 func (w *Writer) Length() int {
 	return len(w.tables)
 }
 
 // Push writes all tables to server.
 // Args:
-//   h: connection handle
+//
+//	h: connection handle
+//
 // Returns:
-//   error: push failure
+//
+//	error: push failure
+//
 // Example:
-//   err := w.Push(handle) // → nil or error
+//
+//	err := w.Push(handle) // → nil or error
 func (w *Writer) Push(h HandleType) error {
 	var pinner runtime.Pinner
 	defer pinner.Unpin()
@@ -149,7 +180,7 @@ func (w *Writer) Push(h HandleType) error {
 		i++
 	}
 
-	var tableSchemas = (**C.qdb_exp_batch_push_table_schema_t)(nil)
+	tableSchemas := (**C.qdb_exp_batch_push_table_schema_t)(nil)
 
 	var options C.qdb_exp_batch_options_t
 	options = w.options.setNative(options)
@@ -169,11 +200,11 @@ func (w *Writer) Push(h HandleType) error {
 		C.qdb_size_t(len(tblSlice)),
 	)
 	elapsed := time.Since(start)
-	
+
 	if errCode == 0 {
 		L().Info("wrote rows", "count", totalRows, "duration", elapsed)
 	}
-	
+
 	return makeErrorOrNil(C.qdb_error_t(errCode))
 }
 

--- a/writer.go
+++ b/writer.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2009-2025, quasardb SAS. All rights reserved.
+// Package qdb: QuasarDB Go client API
+// Types: Reader, Writer, ColumnData, HandleType
+// Ex: h.NewReader(opts).FetchAll() → batch
 package qdb
 
 /*
@@ -12,78 +16,34 @@ import (
 	"time"
 )
 
-// WriterColumn: metadata for single column.
-// Fields:
-//
-//	ColumnName: identifier
-//	ColumnType: data type
+// WriterColumn holds column metadata.
 type WriterColumn struct {
-	ColumnName string
-	ColumnType TsColumnType
+	ColumnName string       // column identifier
+	ColumnType TsColumnType // data type
 }
 
-// Writer: batches tables for push.
-// Fields:
-//
-//	options: push configuration
-//	tables: name→WriterTable map
+// Writer batches tables for bulk push.
 type Writer struct {
-	options WriterOptions
-	tables  map[string]WriterTable
+	options WriterOptions          // push configuration
+	tables  map[string]WriterTable // table cache
 }
 
-// NewWriter creates writer with options.
-// Args:
-//
-//	options: push configuration
-//
-// Returns:
-//
-//	Writer: configured writer
-//
-// Example:
-//
-//	w := NewWriter(opts) // → Writer{opts, empty map}
+// NewWriter creates a writer with options.
 func NewWriter(options WriterOptions) Writer {
 	return Writer{options: options, tables: make(map[string]WriterTable)}
 }
 
-// NewWriterWithDefaultOptions creates writer with defaults.
-// Returns:
-//
-//	Writer: default configuration
-//
-// Example:
-//
-//	w := NewWriterWithDefaultOptions() // → Writer{default opts}
+// NewWriterWithDefaultOptions creates a writer with default options.
 func NewWriterWithDefaultOptions() Writer {
 	return NewWriter(NewWriterOptions())
 }
 
-// GetOptions returns push configuration.
-// Returns:
-//
-//	WriterOptions: current options
-//
-// Example:
-//
-//	opts := w.GetOptions() // → WriterOptions
+// GetOptions returns the writer's push configuration.
 func (w *Writer) GetOptions() WriterOptions {
 	return w.options
 }
 
-// SetTable adds table to batch.
-// Args:
-//
-//	t: table to add
-//
-// Returns:
-//
-//	error: if exists or schema mismatch
-//
-// Example:
-//
-//	err := w.SetTable(tbl) // → nil or error
+// SetTable adds a table to the writer batch.
 func (w *Writer) SetTable(t WriterTable) error {
 	tableName := t.GetName()
 
@@ -107,19 +67,7 @@ func (w *Writer) SetTable(t WriterTable) error {
 	return nil
 }
 
-// GetTable retrieves table by name.
-// Args:
-//
-//	name: table identifier
-//
-// Returns:
-//
-//	WriterTable: found table
-//	error: if not found
-//
-// Example:
-//
-//	tbl, err := w.GetTable("my_table") // → WriterTable or error
+// GetTable retrieves a table by name from the writer.
 func (w *Writer) GetTable(name string) (WriterTable, error) {
 	t, ok := w.tables[name]
 	if !ok {
@@ -129,30 +77,12 @@ func (w *Writer) GetTable(name string) (WriterTable, error) {
 	return t, nil
 }
 
-// Length returns table count.
-// Returns:
-//
-//	int: number of tables
-//
-// Example:
-//
-//	n := w.Length() // → 3
+// Length returns the number of tables in the writer.
 func (w *Writer) Length() int {
 	return len(w.tables)
 }
 
-// Push writes all tables to server.
-// Args:
-//
-//	h: connection handle
-//
-// Returns:
-//
-//	error: push failure
-//
-// Example:
-//
-//	err := w.Push(handle) // → nil or error
+// Push writes all tables to the QuasarDB server.
 func (w *Writer) Push(h HandleType) error {
 	var pinner runtime.Pinner
 	defer pinner.Unpin()
@@ -208,10 +138,7 @@ func (w *Writer) Push(h HandleType) error {
 	return wrapError(C.qdb_error_t(errCode), "writer_write", "tables", len(tblSlice))
 }
 
-// writerTableSchemasEqual compares table schemas.
-// In: a, b WriterTable - tables to compare
-// Out: bool - true if identical
-// Ex: writerTableSchemasEqual(t1, t2) → true
+// writerTableSchemasEqual compares schemas of two tables.
 func writerTableSchemasEqual(a, b WriterTable) bool {
 	if len(a.columnInfoByOffset) != len(b.columnInfoByOffset) {
 		return false

--- a/writer_options.go
+++ b/writer_options.go
@@ -35,11 +35,12 @@ const (
 
 // WriterOptions: batch push configuration.
 // Fields:
-//   pushMode: consistency level
-//   dropDuplicates: enable dedup
-//   dropDuplicateColumns: dedup keys
-//   dedupMode: dedup strategy
-//   pushFlags: behavior flags
+//
+//	pushMode: consistency level
+//	dropDuplicates: enable dedup
+//	dropDuplicateColumns: dedup keys
+//	dedupMode: dedup strategy
+//	pushFlags: behavior flags
 type WriterOptions struct {
 	pushMode             WriterPushMode
 	dropDuplicates       bool
@@ -296,5 +297,4 @@ func (options WriterOptions) WithTransactionalPush() WriterOptions {
 func (options WriterOptions) setNative(opts C.qdb_exp_batch_options_t) C.qdb_exp_batch_options_t {
 	opts.mode = C.qdb_exp_batch_push_mode_t(options.pushMode)
 	return opts
-
 }

--- a/writer_options.go
+++ b/writer_options.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2009-2025, quasardb SAS. All rights reserved.
+// Package qdb: QuasarDB Go client API
+// Types: Reader, Writer, ColumnData, HandleType
+// Ex: h.NewReader(opts).FetchAll() → batch
 package qdb
 
 /*
@@ -6,7 +10,7 @@ package qdb
 */
 import "C"
 
-// WriterPushFlag: batch push behavior flags
+// WriterPushFlag controls batch push behavior.
 type WriterPushFlag C.qdb_exp_batch_push_flags_t
 
 const (
@@ -15,7 +19,7 @@ const (
 	WriterPushFlagAsyncClientPush WriterPushFlag = C.qdb_exp_batch_push_flag_asynchronous_client_push
 )
 
-// WriterPushMode: batch push consistency mode
+// WriterPushMode sets batch push consistency level.
 type WriterPushMode C.qdb_exp_batch_push_mode_t
 
 const (
@@ -24,7 +28,7 @@ const (
 	WriterPushModeAsync         WriterPushMode = C.qdb_exp_batch_push_async
 )
 
-// WriterDeduplicationMode: duplicate handling strategy
+// WriterDeduplicationMode controls duplicate handling.
 type WriterDeduplicationMode C.qdb_exp_batch_deduplication_mode_t
 
 const (
@@ -33,28 +37,16 @@ const (
 	WriterDeduplicationModeUpsert   WriterDeduplicationMode = C.qdb_exp_batch_deduplication_mode_upsert
 )
 
-// WriterOptions: batch push configuration.
-// Fields:
-//
-//	pushMode: consistency level
-//	dropDuplicates: enable dedup
-//	dropDuplicateColumns: dedup keys
-//	dedupMode: dedup strategy
-//	pushFlags: behavior flags
+// WriterOptions configures batch push behavior.
 type WriterOptions struct {
-	pushMode             WriterPushMode
-	dropDuplicates       bool
-	dropDuplicateColumns []string
-	dedupMode            WriterDeduplicationMode
-	pushFlags            WriterPushFlag
+	pushMode             WriterPushMode          // consistency level
+	dropDuplicates       bool                    // enable deduplication
+	dropDuplicateColumns []string                // columns for dedup
+	dedupMode            WriterDeduplicationMode // dedup strategy
+	pushFlags            WriterPushFlag          // behavior flags
 }
 
-// NewWriterOptions returns a WriterOptions struct initialized with safe, default settings.
-//
-// Defaults:
-// - Push mode: Transactional (strongest consistency, lowest performance)
-// - Deduplication: Disabled (fastest ingestion, risk of duplicate data)
-// - Write-Through: Enabled (don't pollute the query cache with newly written data)
+// NewWriterOptions creates writer options with safe defaults.
 func NewWriterOptions() WriterOptions {
 	return WriterOptions{
 		pushMode:             WriterPushModeTransactional,
@@ -65,118 +57,56 @@ func NewWriterOptions() WriterOptions {
 	}
 }
 
-// GetPushMode returns the current WriterPushMode configured in WriterOptions.
+// GetPushMode returns the configured push mode.
 func (options WriterOptions) GetPushMode() WriterPushMode {
 	return options.pushMode
 }
 
-// GetDeduplicationMode returns the current deduplication strategy.
+// GetDeduplicationMode returns the deduplication strategy.
 func (options WriterOptions) GetDeduplicationMode() WriterDeduplicationMode {
 	return options.dedupMode
 }
 
-// IsDropDuplicatesEnabled indicates whether deduplication is currently enabled.
+// IsDropDuplicatesEnabled reports if deduplication is enabled.
 func (options WriterOptions) IsDropDuplicatesEnabled() bool {
 	return options.dropDuplicates
 }
 
-// EnableWriteThrough ensures each push bypasses the server-side cache.
-//
-// Decision rationale:
-//   - Write-through avoids stale reads when concurrent clients rely on cache coherency.
-//
-// Key assumptions:
-//   - Other push flags remain intact; we simply set the bit via OR.
-//
-// Performance trade-offs:
-//   - Slightly higher latency as new values are immediately committed.
-//
-// Usage example:
-//
-//	opt := NewWriterOptions().EnableWriteThrough()
+// EnableWriteThrough bypasses server-side cache on push.
 func (options WriterOptions) EnableWriteThrough() WriterOptions {
 	options.pushFlags |= WriterPushFlagWriteThrough
 	return options
 }
 
-// DisableWriteThrough allows caching of newly pushed data on the server.
-//
-// Decision rationale:
-//   - Useful when write-heavy workloads benefit from reduced commit overhead.
-//
-// Key assumptions:
-//   - Caller intentionally accepts potential cache incoherency during writes.
-//
-// Performance trade-offs:
-//   - May serve slightly stale data if cache eviction lags behind writes.
-//
-// Usage example:
-//
-//	opt := NewWriterOptions().DisableWriteThrough()
+// DisableWriteThrough allows server to cache pushed data.
 func (options WriterOptions) DisableWriteThrough() WriterOptions {
 	options.pushFlags &^= WriterPushFlagWriteThrough
 	return options
 }
 
-// IsWriteThroughEnabled reports whether push operations bypass the cache.
-//
-// Decision rationale:
-//   - Helps unit tests verify flag manipulation logic.
+// IsWriteThroughEnabled reports if write-through is enabled.
 func (options WriterOptions) IsWriteThroughEnabled() bool {
 	return options.pushFlags&WriterPushFlagWriteThrough != 0
 }
 
-// EnableAsyncClientPush makes Push return before the server writes data.
-//
-// Decision rationale:
-//   - Enables batching from the client without blocking on disk I/O.
-//
-// Key assumptions:
-//   - Caller handles potential failures asynchronously.
-//
-// Performance trade-offs:
-//   - Higher throughput at the cost of durability on client failure.
-//
-// Usage example:
-//
-//	opt := NewWriterOptions().EnableAsyncClientPush()
+// EnableAsyncClientPush returns before server persistence.
 func (options WriterOptions) EnableAsyncClientPush() WriterOptions {
 	options.pushFlags |= WriterPushFlagAsyncClientPush
 	return options
 }
 
-// DisableAsyncClientPush waits for server acknowledgement before returning.
-//
-// Decision rationale:
-//   - Provides stronger durability guarantees for each push.
-//
-// Key assumptions:
-//   - Caller desires synchronous semantics and accepts reduced throughput.
-//
-// Performance trade-offs:
-//   - Slower ingestion but easier error handling.
-//
-// Usage example:
-//
-//	opt := NewWriterOptions().DisableAsyncClientPush()
+// DisableAsyncClientPush waits for server acknowledgement.
 func (options WriterOptions) DisableAsyncClientPush() WriterOptions {
 	options.pushFlags &^= WriterPushFlagAsyncClientPush
 	return options
 }
 
-// IsAsyncClientPushEnabled reports whether pushes return before data is persisted.
-//
-// Decision rationale:
-//   - Mirrors Enable/Disable helpers for symmetric API design.
+// IsAsyncClientPushEnabled reports if async push is enabled.
 func (options WriterOptions) IsAsyncClientPushEnabled() bool {
 	return options.pushFlags&WriterPushFlagAsyncClientPush != 0
 }
 
-// EnableDropDuplicates activates deduplication across all columns.
-//
-// Trade-off:
-//   - Increases CPU and memory overhead slightly due to additional hashing/comparison,
-//     but ensures data uniqueness across the full row.
+// EnableDropDuplicates activates deduplication on all columns.
 func (options WriterOptions) EnableDropDuplicates() WriterOptions {
 	options.dropDuplicates = true
 	if options.dedupMode == WriterDeduplicationModeDisabled {
@@ -185,13 +115,7 @@ func (options WriterOptions) EnableDropDuplicates() WriterOptions {
 	return options
 }
 
-// EnableDropDuplicatesOn activates deduplication limited to specific columns.
-//
-// Assumption:
-// - Caller specifies at least one valid column; validation is deferred.
-//
-// Performance implication:
-// - Reduces overhead compared to full-row deduplication, useful for large, wide tables.
+// EnableDropDuplicatesOn activates deduplication on specific columns.
 func (options WriterOptions) EnableDropDuplicatesOn(columns []string) WriterOptions {
 	options.dropDuplicates = true
 	options.dropDuplicateColumns = columns
@@ -201,19 +125,12 @@ func (options WriterOptions) EnableDropDuplicatesOn(columns []string) WriterOpti
 	return options
 }
 
-// GetDropDuplicateColumns returns a slice of columns targeted for deduplication.
-//
-// Behavior:
-// - Empty slice implies deduplication is performed across all columns.
+// GetDropDuplicateColumns returns columns used for deduplication.
 func (options WriterOptions) GetDropDuplicateColumns() []string {
 	return options.dropDuplicateColumns
 }
 
-// IsValid validates the combination of WriterOptions fields.
-//
-// Decision rationale:
-//   - Centralized sanity checks simplify downstream validation and generators.
-//   - Mirrors checks performed during conversion in WriterTable.toNative.
+// IsValid checks if the options are correctly configured.
 func (options WriterOptions) IsValid() bool {
 	switch options.pushMode {
 	case WriterPushModeTransactional, WriterPushModeFast, WriterPushModeAsync:
@@ -247,53 +164,35 @@ func (options WriterOptions) IsValid() bool {
 	return true
 }
 
-// WithPushMode sets the desired push mode and returns an updated copy of WriterOptions.
-//
-// Trade-offs:
-// - Transactional: High consistency guarantees, slower performance
-// - Fast/Async: Lower consistency, higher throughput
+// WithPushMode sets the push mode.
 func (options WriterOptions) WithPushMode(mode WriterPushMode) WriterOptions {
 	options.pushMode = mode
 	return options
 }
 
-// WithDeduplicationMode explicitly sets deduplication behavior.
-//
-// Assumption:
-// - Upsert mode validity depends on provided columns; caller must ensure correct usage.
-//
-// Implications:
-// - Enabling any deduplication mode activates dropDuplicates automatically.
+// WithDeduplicationMode sets the deduplication mode.
 func (options WriterOptions) WithDeduplicationMode(mode WriterDeduplicationMode) WriterOptions {
 	options.dedupMode = mode
 	options.dropDuplicates = mode != WriterDeduplicationModeDisabled
 	return options
 }
 
-// WithAsyncPush is a convenience method equivalent to WithPushMode(WriterPushModeAsync).
+// WithAsyncPush enables async push mode.
 func (options WriterOptions) WithAsyncPush() WriterOptions {
 	return options.WithPushMode(WriterPushModeAsync)
 }
 
-// WithFastPush is a convenience method equivalent to WithPushMode(WriterPushModeFast).
+// WithFastPush enables fast push mode.
 func (options WriterOptions) WithFastPush() WriterOptions {
 	return options.WithPushMode(WriterPushModeFast)
 }
 
-// WithTransactionalPush is a convenience method equivalent to WithPushMode(WriterPushModeTransactional).
+// WithTransactionalPush enables transactional push mode.
 func (options WriterOptions) WithTransactionalPush() WriterOptions {
 	return options.WithPushMode(WriterPushModeTransactional)
 }
 
-// setNative transfers specific fields from WriterOptions into a native C struct qdb_exp_batch_options_t.
-//
-// Important:
-//   - This method intentionally mutates only a subset of the fields in the native struct.
-//   - Fields not explicitly set here must be configured separately.
-//
-// Rationale:
-//   - Direct mapping from WriterOptions to qdb_exp_batch_options_t is not 1:1; some options are
-//     managed elsewhere due to structural differences between Go and native representations.
+// setNative converts options to C struct.
 func (options WriterOptions) setNative(opts C.qdb_exp_batch_options_t) C.qdb_exp_batch_options_t {
 	opts.mode = C.qdb_exp_batch_push_mode_t(options.pushMode)
 	return opts

--- a/writer_table.go
+++ b/writer_table.go
@@ -63,27 +63,36 @@ func NewWriterTable(t string, cols []WriterColumn) (WriterTable, error) {
 
 // GetName returns table identifier.
 // Returns:
-//   string: table name
+//
+//	string: table name
+//
 // Example:
-//   name := t.GetName() // → "metrics"
+//
+//	name := t.GetName() // → "metrics"
 func (t *WriterTable) GetName() string {
 	return t.TableName
 }
 
 // RowCount returns row count.
 // Returns:
-//   int: number of rows
+//
+//	int: number of rows
+//
 // Example:
-//   n := t.RowCount() // → 1000
+//
+//	n := t.RowCount() // → 1000
 func (t *WriterTable) RowCount() int {
 	return t.rowCount
 }
 
 // SetIndexFromNative sets native timestamps.
 // Args:
-//   idx: C timespec array
+//
+//	idx: C timespec array
+//
 // Example:
-//   t.SetIndexFromNative(cTimes) // sets index
+//
+//	t.SetIndexFromNative(cTimes) // sets index
 func (t *WriterTable) SetIndexFromNative(idx []C.qdb_timespec_t) {
 	t.idx = idx
 	t.rowCount = len(idx)
@@ -91,55 +100,65 @@ func (t *WriterTable) SetIndexFromNative(idx []C.qdb_timespec_t) {
 
 // SetIndex sets timestamp index.
 // Args:
-//   idx: timestamps
+//
+//	idx: timestamps
+//
 // Example:
-//   t.SetIndex(times) // sets row timestamps
+//
+//	t.SetIndex(times) // sets row timestamps
 func (t *WriterTable) SetIndex(idx []time.Time) {
 	t.SetIndexFromNative(TimeSliceToQdbTimespec(idx))
 }
 
 // GetIndexAsNative returns native timestamps.
 // Returns:
-//   []C.qdb_timespec_t: C format times
+//
+//	[]C.qdb_timespec_t: C format times
+//
 // Example:
-//   cTimes := t.GetIndexAsNative() // → []timespec
+//
+//	cTimes := t.GetIndexAsNative() // → []timespec
 func (t *WriterTable) GetIndexAsNative() []C.qdb_timespec_t {
 	return t.idx
 }
 
 // GetIndex returns timestamp index.
 // Returns:
-//   []time.Time: row timestamps
+//
+//	[]time.Time: row timestamps
+//
 // Example:
-//   times := t.GetIndex() // → []time.Time
+//
+//	times := t.GetIndex() // → []time.Time
 func (t *WriterTable) GetIndex() []time.Time {
 	return QdbTimespecSliceToTime(t.GetIndexAsNative())
 }
 
- // toNativeTableData initialises `out` so it can be passed directly to
- // qdb_exp_batch_push_with_options.
- //
- // Decision rationale:
- //   - Avoid copies: the timestamp index and every numeric/timespec column
- //     are passed zero-copy by pinning the backing Go slices.
- //   - Keep memory-ownership crystal clear: every temporary C allocation
- //     made here is registered in a slice and folded into ONE `release`
- //     closure returned to the caller.
- //
- // Key assumptions:
- //   - t.idx, t.data and t.columnInfoByOffset have already been validated.
- //   - `pinner` outlives the C call that will consume `out`.
- //   - Each ColumnData implementation obeys CGO pointer-safety when
- //     returning from PinToC.
- //
- // Performance trade-offs:
- //   - Exactly one C allocation for the column envelope (O(#columns));
- //     all row-level data stays in Go memory.
- //
- // Usage example:
- //   rel, err := tbl.toNativeTableData(&pinner, h, &cTbl.data)
- //   if err != nil { … }
- //   defer rel()   // single call releases every allocation done here.
+// toNativeTableData initialises `out` so it can be passed directly to
+// qdb_exp_batch_push_with_options.
+//
+// Decision rationale:
+//   - Avoid copies: the timestamp index and every numeric/timespec column
+//     are passed zero-copy by pinning the backing Go slices.
+//   - Keep memory-ownership crystal clear: every temporary C allocation
+//     made here is registered in a slice and folded into ONE `release`
+//     closure returned to the caller.
+//
+// Key assumptions:
+//   - t.idx, t.data and t.columnInfoByOffset have already been validated.
+//   - `pinner` outlives the C call that will consume `out`.
+//   - Each ColumnData implementation obeys CGO pointer-safety when
+//     returning from PinToC.
+//
+// Performance trade-offs:
+//   - Exactly one C allocation for the column envelope (O(#columns));
+//     all row-level data stays in Go memory.
+//
+// Usage example:
+//
+//	rel, err := tbl.toNativeTableData(&pinner, h, &cTbl.data)
+//	if err != nil { … }
+//	defer rel()   // single call releases every allocation done here.
 func (t *WriterTable) toNativeTableData(pinner *runtime.Pinner, h HandleType, out *C.qdb_exp_batch_push_table_data_t) (func(), error) {
 	// Set row and column counts directly.
 	out.row_count = C.qdb_size_t(t.rowCount)
@@ -200,26 +219,27 @@ func (t *WriterTable) toNativeTableData(pinner *runtime.Pinner, h HandleType, ou
 	return releaseAll, nil
 }
 
- // toNative converts a WriterTable into the flat
- // qdb_exp_batch_push_table_t required by the batch writer.
- //
- // Decision rationale:
- //   - Encapsulate every table-level conversion and gather the subordinate
- //     column release callbacks into a single closure, mirroring the
- //     semantics of multiple defers while incurring only one.
- //
- // Key assumptions:
- //   - `pinner` survives until the batch push completes.
- //   - `opts` were validated in Writer.Push.
- //
- // Performance trade-offs:
- //   - No data copies; only minimal envelope allocations done in
- //     toNativeTableData.
- //
- // Usage example:
- //   rel, err := tbl.toNative(&pinner, h, opts, &cTbl)
- //   if err != nil { … }
- //   defer rel()
+// toNative converts a WriterTable into the flat
+// qdb_exp_batch_push_table_t required by the batch writer.
+//
+// Decision rationale:
+//   - Encapsulate every table-level conversion and gather the subordinate
+//     column release callbacks into a single closure, mirroring the
+//     semantics of multiple defers while incurring only one.
+//
+// Key assumptions:
+//   - `pinner` survives until the batch push completes.
+//   - `opts` were validated in Writer.Push.
+//
+// Performance trade-offs:
+//   - No data copies; only minimal envelope allocations done in
+//     toNativeTableData.
+//
+// Usage example:
+//
+//	rel, err := tbl.toNative(&pinner, h, opts, &cTbl)
+//	if err != nil { … }
+//	defer rel()
 func (t *WriterTable) toNative(pinner *runtime.Pinner, h HandleType, opts WriterOptions, out *C.qdb_exp_batch_push_table_t) (func(), error) {
 	var err error
 
@@ -290,12 +310,17 @@ func (t *WriterTable) toNative(pinner *runtime.Pinner, h HandleType, opts Writer
 
 // SetData assigns column data by offset.
 // Args:
-//   offset: column index
-//   xs: data to set
+//
+//	offset: column index
+//	xs: data to set
+//
 // Returns:
-//   error: if offset invalid or type mismatch
+//
+//	error: if offset invalid or type mismatch
+//
 // Example:
-//   err := t.SetData(0, colData) // → nil or error
+//
+//	err := t.SetData(0, colData) // → nil or error
 func (t *WriterTable) SetData(offset int, xs ColumnData) error {
 	if len(t.columnInfoByOffset) <= offset {
 		return fmt.Errorf("Column offset out of range: %v", offset)
@@ -313,15 +338,19 @@ func (t *WriterTable) SetData(offset int, xs ColumnData) error {
 
 // SetDatas assigns all column data.
 // Args:
-//   xs: data for each column
+//
+//	xs: data for each column
+//
 // Returns:
-//   error: if any assignment fails
+//
+//	error: if any assignment fails
+//
 // Example:
-//   err := t.SetDatas(allData) // → nil or error
+//
+//	err := t.SetDatas(allData) // → nil or error
 func (t *WriterTable) SetDatas(xs []ColumnData) error {
 	for i, x := range xs {
 		err := t.SetData(i, x)
-
 		if err != nil {
 			return err
 		}
@@ -332,12 +361,17 @@ func (t *WriterTable) SetDatas(xs []ColumnData) error {
 
 // GetData retrieves column data by offset.
 // Args:
-//   offset: column index
+//
+//	offset: column index
+//
 // Returns:
-//   ColumnData: column data
-//   error: if offset invalid
+//
+//	ColumnData: column data
+//	error: if offset invalid
+//
 // Example:
-//   data, err := t.GetData(0) // → ColumnData or error
+//
+//	data, err := t.GetData(0) // → ColumnData or error
 func (t *WriterTable) GetData(offset int) (ColumnData, error) {
 	if offset >= len(t.data) {
 		return nil, fmt.Errorf("Column offset out of range: %v", offset)

--- a/writer_table.go
+++ b/writer_table.go
@@ -1,3 +1,7 @@
+// Copyright (c) 2009-2025, quasardb SAS. All rights reserved.
+// Package qdb: QuasarDB Go client API
+// Types: Reader, Writer, ColumnData, HandleType
+// Ex: h.NewReader(opts).FetchAll() → batch
 package qdb
 
 /*
@@ -13,8 +17,7 @@ import (
 	"unsafe"
 )
 
-// WriterTable: table data for batch push.
-// Invariants: len(idx)=rowCount, len(data[i])=rowCount
+// WriterTable holds table data for batch push.
 type WriterTable struct {
 	TableName string
 
@@ -35,18 +38,7 @@ type WriterTable struct {
 	data []ColumnData
 }
 
-// NewWriterTable constructs an empty table definition using the provided columns.
-//
-// Decision rationale:
-//   - Precomputes both column name→offset and offset→column mappings for
-//     efficient validation during SetData and Push.
-//
-// Key assumptions:
-//   - cols contains at least one column and no duplicate names.
-//
-// Performance trade-offs:
-//   - Linear initialization to build the lookup maps; negligible for typical
-//     column counts.
+// NewWriterTable creates a table with the given columns.
 func NewWriterTable(t string, cols []WriterColumn) (WriterTable, error) {
 	data := make([]ColumnData, len(cols))
 
@@ -61,75 +53,33 @@ func NewWriterTable(t string, cols []WriterColumn) (WriterTable, error) {
 	return WriterTable{t, 0, columnInfoByOffset, columnOffsetByName, nil, data}, nil
 }
 
-// GetName returns table identifier.
-// Returns:
-//
-//	string: table name
-//
-// Example:
-//
-//	name := t.GetName() // → "metrics"
+// GetName returns the table name.
 func (t *WriterTable) GetName() string {
 	return t.TableName
 }
 
-// RowCount returns row count.
-// Returns:
-//
-//	int: number of rows
-//
-// Example:
-//
-//	n := t.RowCount() // → 1000
+// RowCount returns the number of rows in the table.
 func (t *WriterTable) RowCount() int {
 	return t.rowCount
 }
 
-// SetIndexFromNative sets native timestamps.
-// Args:
-//
-//	idx: C timespec array
-//
-// Example:
-//
-//	t.SetIndexFromNative(cTimes) // sets index
+// SetIndexFromNative sets the table's timestamp index from C timespecs.
 func (t *WriterTable) SetIndexFromNative(idx []C.qdb_timespec_t) {
 	t.idx = idx
 	t.rowCount = len(idx)
 }
 
-// SetIndex sets timestamp index.
-// Args:
-//
-//	idx: timestamps
-//
-// Example:
-//
-//	t.SetIndex(times) // sets row timestamps
+// SetIndex sets the table's timestamp index.
 func (t *WriterTable) SetIndex(idx []time.Time) {
 	t.SetIndexFromNative(TimeSliceToQdbTimespec(idx))
 }
 
-// GetIndexAsNative returns native timestamps.
-// Returns:
-//
-//	[]C.qdb_timespec_t: C format times
-//
-// Example:
-//
-//	cTimes := t.GetIndexAsNative() // → []timespec
+// GetIndexAsNative returns the timestamp index as C timespecs.
 func (t *WriterTable) GetIndexAsNative() []C.qdb_timespec_t {
 	return t.idx
 }
 
-// GetIndex returns timestamp index.
-// Returns:
-//
-//	[]time.Time: row timestamps
-//
-// Example:
-//
-//	times := t.GetIndex() // → []time.Time
+// GetIndex returns the table's timestamp index.
 func (t *WriterTable) GetIndex() []time.Time {
 	return QdbTimespecSliceToTime(t.GetIndexAsNative())
 }
@@ -308,19 +258,7 @@ func (t *WriterTable) toNative(pinner *runtime.Pinner, h HandleType, opts Writer
 	return release, nil
 }
 
-// SetData assigns column data by offset.
-// Args:
-//
-//	offset: column index
-//	xs: data to set
-//
-// Returns:
-//
-//	error: if offset invalid or type mismatch
-//
-// Example:
-//
-//	err := t.SetData(0, colData) // → nil or error
+// SetData sets column data at the given offset.
 func (t *WriterTable) SetData(offset int, xs ColumnData) error {
 	if len(t.columnInfoByOffset) <= offset {
 		return fmt.Errorf("Column offset out of range: %v", offset)
@@ -336,18 +274,7 @@ func (t *WriterTable) SetData(offset int, xs ColumnData) error {
 	return nil
 }
 
-// SetDatas assigns all column data.
-// Args:
-//
-//	xs: data for each column
-//
-// Returns:
-//
-//	error: if any assignment fails
-//
-// Example:
-//
-//	err := t.SetDatas(allData) // → nil or error
+// SetDatas sets data for all columns.
 func (t *WriterTable) SetDatas(xs []ColumnData) error {
 	for i, x := range xs {
 		err := t.SetData(i, x)
@@ -359,19 +286,7 @@ func (t *WriterTable) SetDatas(xs []ColumnData) error {
 	return nil
 }
 
-// GetData retrieves column data by offset.
-// Args:
-//
-//	offset: column index
-//
-// Returns:
-//
-//	ColumnData: column data
-//	error: if offset invalid
-//
-// Example:
-//
-//	data, err := t.GetData(0) // → ColumnData or error
+// GetData retrieves column data at the given offset.
 func (t *WriterTable) GetData(offset int) (ColumnData, error) {
 	if offset >= len(t.data) {
 		return nil, fmt.Errorf("Column offset out of range: %v", offset)

--- a/writer_test.go
+++ b/writer_test.go
@@ -323,12 +323,12 @@ func TestWriterCanPushTables(t *testing.T) {
 		require.NoError(rt, writer.Push(handle))
 	})
 }
+
 func TestWriterCanDeduplicate(t *testing.T) {
 	handle := newTestHandle(t)
 	defer handle.Close()
 
 	rapid.Check(t, func(rt *rapid.T) {
-
 		assert := assert.New(rt)
 		require := require.New(rt)
 


### PR DESCRIPTION
Makes error management compatible with Golang 1.13+ and Golang 1.18+ standards. Improves linting issues. Adds central interface for `IsRetryable()` to determine whether an error is fatal or can be retried (defaults to retryable).