### PR TITLE
Fix resource leak in reader/writer tests

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -96,7 +96,7 @@ func TestReaderCanOpenWithValidOptions(t *testing.T) {
 
 func TestReaderCanReadDataFromTables(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
-		handle := newTestHandle(t)
+		handle := newTestHandle(rt)
 		// Cleanup handled automatically by newTestHandle()
 
 		WithGCAndHandle(rt, handle, "TestReaderCanReadDataFromTables", func() {

--- a/writer_test.go
+++ b/writer_test.go
@@ -308,7 +308,7 @@ func TestWriterOptionsGenerator(t *testing.T) {
 // TestWriterCanPushTables verifies the writer can push one or more tables using random options.
 func TestWriterCanPushTables(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
-		handle := newTestHandle(t)
+		handle := newTestHandle(rt)
 
 		WithGCAndHandle(rt, handle, "TestWriterCanPushTables", func() {
 			tables := genPopulatedTables(rt, handle)


### PR DESCRIPTION
There was a resource leak in the reader/writer tests. This surfaced as a timeout / build failure on win32, but all platforms / OS'es were affected.

This was a test-only bug.