### PR TITLE
QDB-19170 - Avoid Go write barriers when storing C pointers in CGo structs

### DIFF
--- a/column_data.go
+++ b/column_data.go
@@ -520,8 +520,10 @@ func (cd *ColumnDataBlob) PinToC(h HandleType) (builder PinnableBuilder, release
 	envelope := qdbAllocBuffer[C.qdb_blob_t](h, len(cd.xs))
 	envelopeSlice := unsafe.Slice(envelope, len(cd.xs))
 
-	// Track copied blobs for cleanup
-	copiedBlobs := make([]unsafe.Pointer, 0, len(cd.xs))
+	// Track copied blobs for cleanup. Held as uintptr (not []unsafe.Pointer) so
+	// the GC neither scans these C pointers nor emits a write barrier when they
+	// are appended. See setCPtr in utils.go.
+	copiedBlobs := make([]uintptr, 0, len(cd.xs))
 
 	// No objects to pin - we're copying instead
 
@@ -529,22 +531,23 @@ func (cd *ColumnDataBlob) PinToC(h HandleType) (builder PinnableBuilder, release
 			// Build C structures (executed in Phase 2.5 after pinning)
 			for i, blob := range cd.xs {
 				if len(blob) > 0 {
-					// Copy blob to C memory
+					// Copy blob to C memory. The envelope is C memory; store
+					// barrier-free.
 					blobPtr := qdbAllocAndCopyBytes(h, blob)
-					copiedBlobs = append(copiedBlobs, blobPtr)
-					envelopeSlice[i].content = blobPtr
+					copiedBlobs = append(copiedBlobs, uintptr(blobPtr))
+					setCPtr(unsafe.Pointer(&envelopeSlice[i].content), blobPtr)
 					envelopeSlice[i].content_length = C.qdb_size_t(len(blob))
 				} else {
-					envelopeSlice[i].content = nil
+					setCPtr(unsafe.Pointer(&envelopeSlice[i].content), nil)
 					envelopeSlice[i].content_length = 0
 				}
 			}
 
 			return unsafe.Pointer(envelope)
 		}), func() {
-			// Release all copied blobs
+			// Release all copied blobs (held as uintptr; stable C pointers).
 			for _, blobPtr := range copiedBlobs {
-				qdbReleasePointer(h, blobPtr)
+				releaseCU(h, blobPtr)
 			}
 			// Release envelope
 			qdbRelease(h, envelope)
@@ -661,8 +664,10 @@ func (cd *ColumnDataString) PinToC(h HandleType) (builder PinnableBuilder, relea
 	envelope := qdbAllocBuffer[C.qdb_string_t](h, len(cd.xs))
 	envelopeSlice := unsafe.Slice(envelope, len(cd.xs))
 
-	// Track copied strings for cleanup
-	copiedStrings := make([]*C.char, 0, len(cd.xs))
+	// Track copied strings for cleanup. Held as uintptr (not []*C.char) so the
+	// GC neither scans these C pointers nor emits a write barrier when they are
+	// appended. See setCPtr in utils.go.
+	copiedStrings := make([]uintptr, 0, len(cd.xs))
 
 	// No objects to pin - we're copying instead
 
@@ -670,22 +675,23 @@ func (cd *ColumnDataString) PinToC(h HandleType) (builder PinnableBuilder, relea
 			// Build C structures (executed in Phase 2.5 after pinning)
 			for i, str := range cd.xs {
 				if str != "" {
-					// Copy string to C memory (includes null terminator)
+					// Copy string to C memory (includes null terminator). The
+					// envelope is C memory; store barrier-free.
 					cStr := qdbCopyString(h, str)
-					copiedStrings = append(copiedStrings, cStr)
-					envelopeSlice[i].data = cStr
+					copiedStrings = append(copiedStrings, uintptr(unsafe.Pointer(cStr)))
+					setCPtr(unsafe.Pointer(&envelopeSlice[i].data), unsafe.Pointer(cStr))
 					envelopeSlice[i].length = C.qdb_size_t(len(str))
 				} else {
-					envelopeSlice[i].data = nil
+					setCPtr(unsafe.Pointer(&envelopeSlice[i].data), nil)
 					envelopeSlice[i].length = 0
 				}
 			}
 
 			return unsafe.Pointer(envelope)
 		}), func() {
-			// Release all copied strings
+			// Release all copied strings (held as uintptr; stable C pointers).
 			for _, cStr := range copiedStrings {
-				qdbReleasePointer(h, unsafe.Pointer(cStr))
+				releaseCU(h, cStr)
 			}
 			// Release envelope
 			qdbRelease(h, envelope)

--- a/reader.go
+++ b/reader.go
@@ -396,15 +396,20 @@ func NewReader(h HandleType, options ReaderOptions) (Reader, error) {
 	// the QuasarDB allocator so it is compatible with the C API.  Each table name must also be
 	// allocated using qdbCopyString and is immediately deferred for release.
 	tableCount := len(options.tables)
-	cTables := qdbAllocBuffer[C.qdb_bulk_reader_table_t](h, tableCount)
-	defer qdbRelease(h, cTables)
+	// Zeroed C memory: the table name is stored barrier-free via setCPtr, but
+	// `ranges` keeps a normal assignment (it is a Go pointer that the barrier
+	// must shade); zeroing makes that assignment safe (the barrier reads a nil
+	// prior value, not uninitialized garbage). Freed via releaseCPtr so no C
+	// pointer sits in a GC-scanned defer record.
+	cTables := qdbAllocBufferZeroed[C.qdb_bulk_reader_table_t](h, tableCount)
+	defer releaseCPtr(h, unsafe.Pointer(cTables))()
 	tblSlice := unsafe.Slice(cTables, tableCount)
 
 	for i, tbl := range options.tables {
 		name := qdbCopyString(h, tbl)
-		defer qdbRelease(h, name) //nolint:gocritic
+		defer releaseCPtr(h, unsafe.Pointer(name))() //nolint:gocritic
 
-		tblSlice[i].name = name
+		setCPtr(unsafe.Pointer(&tblSlice[i].name), unsafe.Pointer(name))
 		tblSlice[i].ranges = cRangePtr
 		tblSlice[i].range_count = cRangeCount
 	}
@@ -416,12 +421,13 @@ func NewReader(h HandleType, options ReaderOptions) (Reader, error) {
 	var cColumns **C.char
 	if columnCount > 0 {
 		ptr := qdbAllocBuffer[*C.char](h, columnCount)
-		defer qdbRelease(h, ptr)
+		defer releaseCPtr(h, unsafe.Pointer(ptr))()
 		colSlice := unsafe.Slice(ptr, columnCount)
 		for i, col := range options.columns {
 			cname := qdbCopyString(h, col)
-			defer qdbRelease(h, cname) //nolint:gocritic
-			colSlice[i] = cname
+			defer releaseCPtr(h, unsafe.Pointer(cname))() //nolint:gocritic
+			// colSlice backs onto C memory; barrier-free store.
+			setCPtr(unsafe.Pointer(&colSlice[i]), unsafe.Pointer(cname))
 		}
 		cColumns = ptr
 	} else {

--- a/utils.go
+++ b/utils.go
@@ -417,6 +417,22 @@ func qdbAllocBuffer[T any](h HandleType, count int) *T {
 	return (*T)(ptr)
 }
 
+// qdbAllocBufferZeroed allocates `count` elements of T in C memory and zeroes
+// them. Use this (not qdbAllocBuffer) whenever the C API reads struct fields
+// that the caller does not explicitly set: qdbAllocBuffer returns uninitialized
+// memory, so unset fields would be garbage.
+//
+// Zeroing is done byte-wise through a []byte view rather than a struct
+// assignment. Assigning a zero struct value to a cgo struct with pointer-typed
+// fields would emit Go write barriers over the (uninitialized) destination, the
+// exact hazard setCPtr exists to avoid. Byte stores emit no barrier.
+func qdbAllocBufferZeroed[T any](h HandleType, count int) *T {
+	ptr := qdbAllocBuffer[T](h, count)
+	clear(unsafe.Slice((*byte)(unsafe.Pointer(ptr)), int(unsafe.Sizeof(*ptr))*count))
+
+	return ptr
+}
+
 // qdbAllocAndCopyBytes allocates a buffer via C.qdb_copy_alloc_buffer and copies the provided Go slice into it.
 // Returns an arbitrary unsafe.Pointer to C-managed memory. Caller must free via qdbReleasePointer.
 //
@@ -557,6 +573,40 @@ func qdbRelease[T any](h HandleType, ptr *T) {
 //	qdbReleasePointer(h, rawPtr) // release when finished
 func qdbReleasePointer(h HandleType, ptr unsafe.Pointer) {
 	C.qdb_release(h.handle, ptr)
+}
+
+// setCPtr stores a C pointer into a cgo pointer-typed field WITHOUT emitting a
+// Go write barrier. A normal assignment to such a field makes the compiler emit
+// a barrier that (a) reads the slot's prior bytes -- often uninitialized C
+// memory -- as a Go pointer, and (b) hands the GC the C address being stored.
+// Either aborts the runtime ("found bad pointer in Go heap" / "marked free
+// object") when a C address happens to overlap a Go heap arena (data-dependent;
+// seen on amd64 and aarch64). The barrier serves no purpose here: C pointers are
+// never moved or freed by the Go GC. The pinning + runtime.KeepAlive machinery
+// in Writer.Push keeps any referenced Go memory alive across the C call.
+//
+// `field` must be the address of the destination pointer field; `p` is the C
+// pointer (or nil) to store.
+func setCPtr(field, p unsafe.Pointer) {
+	*(*uintptr)(field) = uintptr(p)
+}
+
+// releaseCU frees a C pointer that is held as a uintptr. This is the single
+// place the (safe) uintptr -> unsafe.Pointer round-trip happens: it is valid
+// because C pointers are stable -- the Go GC never moves or frees them -- so the
+// uintptr cannot dangle. Callers hold C pointers as uintptr (not unsafe.Pointer)
+// so the GC neither scans nor rejects them.
+func releaseCU(h HandleType, u uintptr) {
+	qdbReleasePointer(h, unsafe.Pointer(u)) //nolint:govet // stable C pointer held as uintptr
+}
+
+// releaseCPtr returns a cleanup closure that frees the C pointer `p`, holding it
+// as a uintptr so the (Go-heap) closure keeps no C pointer for the GC to scan
+// and reject.
+func releaseCPtr(h HandleType, p unsafe.Pointer) func() {
+	u := uintptr(p)
+
+	return func() { releaseCU(h, u) }
 }
 
 // qdbCopyString allocates a C-style null-terminated copy of a Go string via QDB C API.

--- a/writer.go
+++ b/writer.go
@@ -144,7 +144,15 @@ func (w *Writer) Push(h HandleType) error {
 		return wrapError(C.qdb_e_invalid_argument, "writer_push", "reason", "no tables")
 	}
 
-	tblSlice := make([]C.qdb_exp_batch_push_table_t, w.Length())
+	// Allocate the native table array in C memory rather than with make(): a
+	// Go slice of these structs holds C pointers in its name/columns/
+	// where_duplicate fields, which the GC would scan and reject. C memory is
+	// never scanned. Zeroed so any field the builders do not set is not garbage,
+	// and freed via releaseCPtr after the push (no C pointer captured in a Go
+	// closure). See setCPtr/qdbAllocBufferZeroed in utils.go.
+	tblPtr := qdbAllocBufferZeroed[C.qdb_exp_batch_push_table_t](h, w.Length())
+	releases = append(releases, releaseCPtr(h, unsafe.Pointer(tblPtr)))
+	tblSlice := unsafe.Slice(tblPtr, w.Length())
 	i := 0
 
 	// Phase 1: Prepare - Collect all PinnableBuilders from all tables

--- a/writer_table.go
+++ b/writer_table.go
@@ -211,8 +211,9 @@ func (t *WriterTable) toNativeTableData(h HandleType, out *C.qdb_exp_batch_push_
 	//
 	// RIGHT (what we do here):
 	pinnableBuilders = append(pinnableBuilders, NewPinnableBuilderSingle(&t.idx[0], func() unsafe.Pointer {
-		// This code runs in Phase 2.5, AFTER t.idx[0] is pinned
-		out.timestamps = (*C.qdb_timespec_t)(unsafe.Pointer(&t.idx[0]))
+		// This code runs in Phase 2.5, AFTER t.idx[0] is pinned. Barrier-free
+		// store: out lives in C memory; t.idx[0] is pinned + KeepAlive'd.
+		setCPtr(unsafe.Pointer(&out.timestamps), unsafe.Pointer(&t.idx[0]))
 
 		return unsafe.Pointer(&t.idx[0])
 	}))
@@ -229,10 +230,11 @@ func (t *WriterTable) toNativeTableData(h HandleType, out *C.qdb_exp_batch_push_
 	for i, column := range t.columnInfoByOffset {
 		elem := &colSlice[i]
 
-		// Allocate C string for column name
+		// Allocate C string for column name. Store barrier-free (elem is C
+		// memory) and release via releaseCPtr (no C pointer kept in a Go closure).
 		cName := qdbCopyString(h, column.ColumnName)
-		releases = append(releases, func() { qdbReleasePointer(h, unsafe.Pointer(cName)) })
-		elem.name = cName
+		releases = append(releases, releaseCPtr(h, unsafe.Pointer(cName)))
+		setCPtr(unsafe.Pointer(&elem.name), unsafe.Pointer(cName))
 		elem.data_type = C.qdb_ts_column_type_t(column.ColumnType)
 
 		// Convert column data based on type:
@@ -246,15 +248,18 @@ func (t *WriterTable) toNativeTableData(h HandleType, out *C.qdb_exp_batch_push_
 		// WRONG (all builders would use the last elem):
 		//   Builder: func() { elem.data = ... }  // elem changes each iteration!
 		//
-		// RIGHT (each builder uses its own elem):
-		currentElem := elem     // Capture current iteration's pointer
-		localBuilder := builder // Capture current iteration's builder
+		// RIGHT (each builder uses its own elem): capture the element address as
+		// uintptr, not as a *C pointer -- the closure lives on the Go heap, and a
+		// captured C pointer would be scanned and rejected by the GC.
+		currentElemU := uintptr(unsafe.Pointer(elem)) // Capture current iteration's element addr
+		localBuilder := builder                       // Capture current iteration's builder
 
 		wrappedBuilder := NewPinnableBuilderMultiple(localBuilder.Objects, func() unsafe.Pointer {
 			// This executes in Phase 2.5 with captured variables
 			ptr := localBuilder.Builder()
-			// Store the pointer in the C structure
-			*(*unsafe.Pointer)(unsafe.Pointer(&currentElem.data[0])) = ptr
+			// Store the pointer in the C structure (barrier-free; C memory).
+			currentElem := (*C.qdb_exp_batch_push_column_t)(unsafe.Pointer(currentElemU)) //nolint:govet // stable C pointer held as uintptr
+			setCPtr(unsafe.Pointer(&currentElem.data[0]), ptr)
 
 			return ptr
 		})
@@ -262,8 +267,8 @@ func (t *WriterTable) toNativeTableData(h HandleType, out *C.qdb_exp_batch_push_
 		releases = append(releases, rel)
 	}
 
-	// Store the pointer to the first element.
-	out.columns = cols
+	// Store the pointer to the first element (barrier-free; out is C memory).
+	setCPtr(unsafe.Pointer(&out.columns), unsafe.Pointer(cols))
 
 	// Create a single release function that cleans up all allocations
 	releaseAll := func() {
@@ -301,21 +306,19 @@ func (t *WriterTable) toNative(h HandleType, opts WriterOptions, out *C.qdb_exp_
 
 	var releases []func()
 
-	// Allocate C string for table name
+	// Allocate C string for table name. Store barrier-free (out is C memory) and
+	// release via releaseCPtr (no C pointer kept in a Go closure).
 	cTableName := qdbCopyString(h, t.TableName)
-	// Add table name release to releases
-	releases = append(releases, func() {
-		qdbReleasePointer(h, unsafe.Pointer(cTableName))
-	})
+	releases = append(releases, releaseCPtr(h, unsafe.Pointer(cTableName)))
 
-	out.name = cTableName
+	setCPtr(unsafe.Pointer(&out.name), unsafe.Pointer(cTableName))
 
 	// Zero-initialize the rest of the struct. This should already be the case,
 	// but just in case, we are very explicit about all the default values we
 	// use.
 	//
 	// Insert truncate -- not supported yet
-	out.truncate_ranges = nil
+	setCPtr(unsafe.Pointer(&out.truncate_ranges), nil)
 	out.truncate_range_count = 0
 
 	// Deduplication parameters
@@ -338,14 +341,15 @@ func (t *WriterTable) toNative(h HandleType, opts WriterOptions, out *C.qdb_exp_
 		dupSlice := unsafe.Slice(ptr, count)
 		for i := range opts.dropDuplicateColumns {
 			cDupCol := qdbCopyString(h, opts.dropDuplicateColumns[i])
-			releases = append(releases, func() { qdbReleasePointer(h, unsafe.Pointer(cDupCol)) })
-			dupSlice[i] = cDupCol
+			releases = append(releases, releaseCPtr(h, unsafe.Pointer(cDupCol)))
+			// dupSlice backs onto C memory; barrier-free store.
+			setCPtr(unsafe.Pointer(&dupSlice[i]), unsafe.Pointer(cDupCol))
 		}
 
-		out.where_duplicate = ptr
+		setCPtr(unsafe.Pointer(&out.where_duplicate), unsafe.Pointer(ptr))
 		out.where_duplicate_count = C.qdb_size_t(count)
 	} else {
-		out.where_duplicate = nil
+		setCPtr(unsafe.Pointer(&out.where_duplicate), nil)
 		out.where_duplicate_count = 0
 	}
 


### PR DESCRIPTION
Fixes segfault due to invalid / incorrect memory pinning